### PR TITLE
Add macOS direct-download release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (for example 1.0.0 or v1.0.0)"
+        required: true
+        type: string
+      notarize:
+        description: "Sign and notarize if Apple credentials are available"
+        required: true
+        default: false
+        type: boolean
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-release:
+    runs-on: macos-26
+    timeout-minutes: 45
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME}"
+          else
+            version="${{ inputs.version }}"
+          fi
+          version="${version#v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "build_number=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Import signing certificate
+        if: ${{ inputs.notarize || startsWith(github.ref, 'refs/tags/v') }}
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
+          P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_TEMP_KEYCHAIN_PASSWORD }}
+        shell: bash
+        run: |
+          if [[ -z "${BUILD_CERTIFICATE_BASE64:-}" || -z "${P12_PASSWORD:-}" || -z "${KEYCHAIN_PASSWORD:-}" ]]; then
+            echo "Missing signing certificate secrets." >&2
+            exit 1
+          fi
+          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Build release app
+        env:
+          NOTESBRIDGE_VERSION: ${{ steps.meta.outputs.version }}
+          NOTESBRIDGE_BUILD_NUMBER: ${{ steps.meta.outputs.build_number }}
+          NOTESBRIDGE_BUNDLE_ID: dev.notesbridge.app
+          NOTESBRIDGE_SIGN_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
+          NOTESBRIDGE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          NOTESBRIDGE_NOTARIZE: ${{ (inputs.notarize || startsWith(github.ref, 'refs/tags/v')) && '1' || '0' }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        shell: bash
+        run: |
+          if [[ "${NOTESBRIDGE_NOTARIZE}" == "1" && -z "${NOTESBRIDGE_SIGN_IDENTITY:-}" ]]; then
+            echo "Missing MACOS_DEVELOPER_ID_APPLICATION secret." >&2
+            exit 1
+          fi
+          if [[ "${NOTESBRIDGE_NOTARIZE}" != "1" ]]; then
+            export NOTESBRIDGE_SIGN_IDENTITY="-"
+            export NOTESBRIDGE_TEAM_ID=""
+          fi
+          ./scripts/build-release-app.sh
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: NotesBridge-${{ steps.meta.outputs.version }}-macOS
+          path: |
+            dist/NotesBridge.app
+            dist/NotesBridge-${{ steps.meta.outputs.version }}-macOS.zip
+
+      - name: Create or update GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release create "${{ steps.meta.outputs.tag }}" \
+            "dist/NotesBridge-${{ steps.meta.outputs.version }}-macOS.zip" \
+            --title "NotesBridge ${{ steps.meta.outputs.version }}" \
+            --notes "Direct download build for macOS." \
+          || gh release upload "${{ steps.meta.outputs.tag }}" \
+            "dist/NotesBridge-${{ steps.meta.outputs.version }}-macOS.zip" \
+            --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /.build
 /Packages
+/dist
 xcuserdata/
 DerivedData/
 .swiftpm/configuration/registries.json

--- a/README.md
+++ b/README.md
@@ -62,6 +62,44 @@ If you only want to rebuild the `.app` without launching it:
 
 On first bundled launch, macOS may ask for Accessibility and Automation permissions so NotesBridge can watch Apple Notes and sync its content. The first full sync also asks you to choose `~/Library/Group Containers/group.com.apple.notes` so the app can read NoteStore.sqlite and binary attachments.
 
+## Release for users
+
+For end users, the recommended distribution path is a direct-download macOS app bundle.
+
+- Build a release app bundle with `./scripts/build-release-app.sh`
+- Package it for download as a ZIP archive
+- Sign it with `Developer ID Application`
+- Notarize it with Apple and staple the ticket before upload
+
+The repository now includes:
+
+- `./scripts/build-release-app.sh` for release bundle creation
+- `./scripts/package-release-zip.sh` for direct-download packaging
+- `./scripts/notarize-release.sh` for notarization and stapling
+- `.github/workflows/release.yml` for GitHub Actions release builds
+
+Example local release build:
+
+```bash
+NOTESBRIDGE_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
+NOTESBRIDGE_TEAM_ID="TEAMID" \
+NOTESBRIDGE_VERSION="1.0.0" \
+NOTESBRIDGE_BUILD_NUMBER="100" \
+./scripts/build-release-app.sh
+```
+
+To notarize, also provide:
+
+```bash
+export NOTESBRIDGE_NOTARIZE=1
+export APPLE_ID="you@example.com"
+export APPLE_TEAM_ID="TEAMID"
+export APPLE_APP_SPECIFIC_PASSWORD="app-specific-password"
+./scripts/build-release-app.sh
+```
+
+The final direct-download artifact is produced in `./dist/` and can be uploaded to a GitHub Release for users to install.
+
 ## Suggested next steps
 
 1. Harden selection anchoring and formatting-bar placement across multiple displays and fullscreen spaces.

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BUILD_CONFIG="release"
+OUTPUT_DIR="$ROOT_DIR/dist"
+APP_NAME="NotesBridge"
+BUNDLE_ID="dev.notesbridge.app"
+VERSION="1.0.0"
+BUILD_NUMBER="1"
+SIGN_IDENTITY="-"
+TEAM_ID=""
+LAUNCH_AFTER_BUILD=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --debug                 Build a debug bundle instead of release
+  --output-dir PATH       Output directory for the bundle (default: ./dist)
+  --app-name NAME         App bundle name (default: NotesBridge)
+  --bundle-id ID          CFBundleIdentifier (default: dev.notesbridge.app)
+  --version VERSION       CFBundleShortVersionString (default: 1.0.0)
+  --build-number NUMBER   CFBundleVersion (default: 1)
+  --sign-identity NAME    codesign identity (default: ad-hoc "-")
+  --team-id TEAM          Optional TeamIdentifier for Info.plist
+  --launch                Open the built app after packaging
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --debug)
+            BUILD_CONFIG="debug"
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift
+            ;;
+        --app-name)
+            APP_NAME="$2"
+            shift
+            ;;
+        --bundle-id)
+            BUNDLE_ID="$2"
+            shift
+            ;;
+        --version)
+            VERSION="$2"
+            shift
+            ;;
+        --build-number)
+            BUILD_NUMBER="$2"
+            shift
+            ;;
+        --sign-identity)
+            SIGN_IDENTITY="$2"
+            shift
+            ;;
+        --team-id)
+            TEAM_ID="$2"
+            shift
+            ;;
+        --launch)
+            LAUNCH_AFTER_BUILD=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+EXECUTABLE_PATH="$ROOT_DIR/.build/$BUILD_CONFIG/NotesBridge"
+APP_BUNDLE_PATH="$OUTPUT_DIR/$APP_NAME.app"
+CONTENTS_PATH="$APP_BUNDLE_PATH/Contents"
+MACOS_PATH="$CONTENTS_PATH/MacOS"
+INFO_PLIST_PATH="$CONTENTS_PATH/Info.plist"
+DESIGNATED_REQUIREMENT="=designated => identifier \"$BUNDLE_ID\""
+
+echo "Building NotesBridge ($BUILD_CONFIG)..."
+swift build --package-path "$ROOT_DIR" -c "$BUILD_CONFIG"
+
+if [[ ! -x "$EXECUTABLE_PATH" ]]; then
+    echo "Expected executable was not produced at $EXECUTABLE_PATH" >&2
+    exit 1
+fi
+
+echo "Packaging app bundle at $APP_BUNDLE_PATH..."
+rm -rf "$APP_BUNDLE_PATH"
+mkdir -p "$MACOS_PATH"
+cp "$EXECUTABLE_PATH" "$MACOS_PATH/$APP_NAME"
+
+cat > "$INFO_PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$APP_NAME</string>
+    <key>CFBundleIdentifier</key>
+    <string>$BUNDLE_ID</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$APP_NAME</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$VERSION</string>
+    <key>CFBundleVersion</key>
+    <string>$BUILD_NUMBER</string>
+    <key>LSUIElement</key>
+    <true/>
+$(if [[ -n "$TEAM_ID" ]]; then cat <<TEAM
+    <key>TeamIdentifier</key>
+    <string>$TEAM_ID</string>
+TEAM
+fi)
+</dict>
+</plist>
+PLIST
+
+codesign \
+    --force \
+    --sign "$SIGN_IDENTITY" \
+    --identifier "$BUNDLE_ID" \
+    --requirements "$DESIGNATED_REQUIREMENT" \
+    --deep \
+    "$APP_BUNDLE_PATH" >/dev/null
+
+echo "App bundle ready:"
+echo "  $APP_BUNDLE_PATH"
+echo "  version=$VERSION"
+echo "  build=$BUILD_NUMBER"
+echo "  bundle_id=$BUNDLE_ID"
+echo "  codesign_identity=$SIGN_IDENTITY"
+
+if [[ "$LAUNCH_AFTER_BUILD" -eq 1 ]]; then
+    open -n "$APP_BUNDLE_PATH"
+fi

--- a/scripts/build-release-app.sh
+++ b/scripts/build-release-app.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="$ROOT_DIR/dist"
+
+VERSION="${NOTESBRIDGE_VERSION:-${1:-}}"
+if [[ -z "${VERSION:-}" ]]; then
+    VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo 1.0.0)"
+fi
+VERSION="${VERSION#v}"
+
+BUILD_NUMBER="${NOTESBRIDGE_BUILD_NUMBER:-$(git rev-list --count HEAD)}"
+BUNDLE_ID="${NOTESBRIDGE_BUNDLE_ID:-dev.notesbridge.app}"
+SIGN_IDENTITY="${NOTESBRIDGE_SIGN_IDENTITY:--}"
+TEAM_ID="${NOTESBRIDGE_TEAM_ID:-}"
+APP_NAME="NotesBridge"
+APP_PATH="$OUTPUT_DIR/$APP_NAME.app"
+ZIP_NAME="$APP_NAME-$VERSION-macOS.zip"
+ZIP_PATH="$OUTPUT_DIR/$ZIP_NAME"
+
+build_args=(
+    --output-dir "$OUTPUT_DIR"
+    --app-name "$APP_NAME"
+    --bundle-id "$BUNDLE_ID"
+    --version "$VERSION"
+    --build-number "$BUILD_NUMBER"
+    --sign-identity "$SIGN_IDENTITY"
+)
+
+if [[ -n "$TEAM_ID" ]]; then
+    build_args+=(--team-id "$TEAM_ID")
+fi
+
+"$ROOT_DIR/scripts/build-app-bundle.sh" "${build_args[@]}"
+
+"$ROOT_DIR/scripts/package-release-zip.sh" \
+    --app "$APP_PATH" \
+    --output-dir "$OUTPUT_DIR" \
+    --archive-name "$ZIP_NAME"
+
+if [[ "${NOTESBRIDGE_NOTARIZE:-0}" == "1" ]]; then
+    "$ROOT_DIR/scripts/notarize-release.sh" \
+        --archive "$ZIP_PATH" \
+        --app "$APP_PATH" \
+        --bundle-id "$BUNDLE_ID"
+
+    "$ROOT_DIR/scripts/package-release-zip.sh" \
+        --app "$APP_PATH" \
+        --output-dir "$OUTPUT_DIR" \
+        --archive-name "$ZIP_NAME"
+fi
+
+echo
+echo "Release artifacts ready:"
+echo "  App: $APP_PATH"
+echo "  ZIP: $ZIP_PATH"

--- a/scripts/notarize-release.sh
+++ b/scripts/notarize-release.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+ARCHIVE_PATH=""
+PRIMARY_BUNDLE_ID="dev.notesbridge.app"
+APPLE_ID="${APPLE_ID:-}"
+APPLE_TEAM_ID="${APPLE_TEAM_ID:-}"
+APPLE_APP_SPECIFIC_PASSWORD="${APPLE_APP_SPECIFIC_PASSWORD:-}"
+APP_PATH=""
+
+usage() {
+    cat <<EOF
+Usage: $0 --archive PATH --app PATH [--bundle-id ID]
+
+Required environment variables:
+  APPLE_ID
+  APPLE_TEAM_ID
+  APPLE_APP_SPECIFIC_PASSWORD
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --archive)
+            ARCHIVE_PATH="$2"
+            shift
+            ;;
+        --app)
+            APP_PATH="$2"
+            shift
+            ;;
+        --bundle-id)
+            PRIMARY_BUNDLE_ID="$2"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [[ -z "$ARCHIVE_PATH" || -z "$APP_PATH" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -f "$ARCHIVE_PATH" ]]; then
+    echo "Archive not found: $ARCHIVE_PATH" >&2
+    exit 1
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "App bundle not found: $APP_PATH" >&2
+    exit 1
+fi
+
+if [[ -z "$APPLE_ID" || -z "$APPLE_TEAM_ID" || -z "$APPLE_APP_SPECIFIC_PASSWORD" ]]; then
+    echo "Missing notarization credentials in environment." >&2
+    usage >&2
+    exit 1
+fi
+
+echo "Submitting archive for notarization..."
+xcrun notarytool submit "$ARCHIVE_PATH" \
+    --apple-id "$APPLE_ID" \
+    --team-id "$APPLE_TEAM_ID" \
+    --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+    --wait
+
+echo "Stapling notarization ticket..."
+xcrun stapler staple "$APP_PATH"
+
+echo "Notarization complete for:"
+echo "  $APP_PATH"

--- a/scripts/package-release-zip.sh
+++ b/scripts/package-release-zip.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+APP_PATH=""
+OUTPUT_DIR="$ROOT_DIR/dist"
+ARCHIVE_NAME=""
+
+usage() {
+    cat <<EOF
+Usage: $0 --app PATH [--output-dir PATH] [--archive-name NAME]
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --app)
+            APP_PATH="$2"
+            shift
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift
+            ;;
+        --archive-name)
+            ARCHIVE_NAME="$2"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [[ -z "$APP_PATH" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "App bundle not found: $APP_PATH" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+APP_BASENAME="$(basename "$APP_PATH" .app)"
+if [[ -z "$ARCHIVE_NAME" ]]; then
+    ARCHIVE_NAME="$APP_BASENAME.zip"
+fi
+
+ARCHIVE_PATH="$OUTPUT_DIR/$ARCHIVE_NAME"
+rm -f "$ARCHIVE_PATH"
+
+ditto -c -k --keepParent "$APP_PATH" "$ARCHIVE_PATH"
+
+echo "ZIP archive ready:"
+echo "  $ARCHIVE_PATH"

--- a/scripts/run-bundled-app.sh
+++ b/scripts/run-bundled-app.sh
@@ -22,62 +22,15 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-EXECUTABLE_PATH="$ROOT_DIR/.build/$BUILD_CONFIG/NotesBridge"
 APP_SUPPORT_DIR="$HOME/Library/Application Support/NotesBridge"
 APP_BUNDLE_PATH="$APP_SUPPORT_DIR/NotesBridge.app"
-CONTENTS_PATH="$APP_BUNDLE_PATH/Contents"
-MACOS_PATH="$CONTENTS_PATH/MacOS"
-INFO_PLIST_PATH="$CONTENTS_PATH/Info.plist"
-BUNDLE_IDENTIFIER="dev.notesbridge.app"
-DESIGNATED_REQUIREMENT='=designated => identifier "dev.notesbridge.app"'
-
-echo "Building NotesBridge ($BUILD_CONFIG)..."
-swift build --package-path "$ROOT_DIR" -c "$BUILD_CONFIG"
-
-if [[ ! -x "$EXECUTABLE_PATH" ]]; then
-    echo "Expected executable was not produced at $EXECUTABLE_PATH" >&2
-    exit 1
-fi
-
-echo "Packaging app bundle at $APP_BUNDLE_PATH..."
-rm -rf "$APP_BUNDLE_PATH"
-mkdir -p "$MACOS_PATH"
-cp "$EXECUTABLE_PATH" "$MACOS_PATH/NotesBridge"
-
-cat > "$INFO_PLIST_PATH" <<'PLIST'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleDevelopmentRegion</key>
-    <string>en</string>
-    <key>CFBundleExecutable</key>
-    <string>NotesBridge</string>
-    <key>CFBundleIdentifier</key>
-    <string>dev.notesbridge.app</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleName</key>
-    <string>NotesBridge</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
-    <key>CFBundleVersion</key>
-    <string>1</string>
-    <key>LSUIElement</key>
-    <true/>
-</dict>
-</plist>
-PLIST
-
-codesign \
-    --force \
-    --sign - \
-    --identifier "$BUNDLE_IDENTIFIER" \
-    --requirements "$DESIGNATED_REQUIREMENT" \
-    --deep \
-    "$APP_BUNDLE_PATH" >/dev/null
+"$ROOT_DIR/scripts/build-app-bundle.sh" \
+    $( [[ "$BUILD_CONFIG" == "debug" ]] && printf '%s' "--debug" ) \
+    --output-dir "$APP_SUPPORT_DIR" \
+    --app-name "NotesBridge" \
+    --bundle-id "dev.notesbridge.app" \
+    --version "1.0" \
+    --build-number "1"
 
 echo "Bundled app ready:"
 echo "  $APP_BUNDLE_PATH"


### PR DESCRIPTION
## Summary
- add scripts to build, package, and notarize a direct-download NotesBridge.app release
- add a GitHub Actions release workflow for tagged or manually triggered builds
- update the bundled app script and README to use and document the new release pipeline

## Validation
- `bash -n scripts/build-app-bundle.sh scripts/build-release-app.sh scripts/notarize-release.sh scripts/package-release-zip.sh scripts/run-bundled-app.sh`
- `swift test`
- `NOTESBRIDGE_VERSION=1.0.0-test NOTESBRIDGE_BUILD_NUMBER=999 ./scripts/build-release-app.sh`

## Notes
- direct pushes to `main` were avoided; this PR carries the release infrastructure changes only.
- `dist/` is now ignored and stays local as a build artifact directory.