### PR TITLE
feat(site): add local multi-language support for landing page

### DIFF
--- a/site/index.fr.html
+++ b/site/index.fr.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NotesBridge | Compagnon Apple Notes vers Markdown pour macOS</title>
+    <meta
+      name="description"
+      content="NotesBridge est une application compagnon native macOS pour Apple Notes. Elle ajoute des outils d'édition en ligne et exporte des notes vers des dossiers Markdown locaux."
+    >
+    <meta name="theme-color" content="#fdfaf3">
+    <meta property="og:title" content="NotesBridge">
+    <meta
+      property="og:description"
+      content="Apple Notes pour la capture. Markdown pour la copie durable."
+    >
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://peizh.github.io/NotesBridge/index.fr.html">
+    <meta
+      property="og:image"
+      content="https://peizh.github.io/NotesBridge/assets/notesbridge-social.svg"
+    >
+    <link rel="icon" href="./assets/notesbridge-app-icon.svg" type="image/svg+xml">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700;9..144,800&family=Manrope:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Accueil NotesBridge">
+          <img src="./assets/notesbridge-app-icon.svg" alt="Icône NotesBridge">
+          <span>NotesBridge</span>
+        </a>
+        <nav class="topnav" aria-label="Primaire">
+          <a href="#proof">Fonctionnalités</a>
+          <a href="#workflow">Flux de travail</a>
+          <a href="#faq">FAQ</a>
+        </nav>
+        <a class="topbar-action" href="https://github.com/peizh/NotesBridge/releases">
+          Télécharger
+        </a>
+      </header>
+
+      <main id="top">
+        <section class="hero">
+          <div class="hero-copy">
+            <p class="eyebrow">Un compagnon macOS pour Apple Notes</p>
+            <h1>Apple Notes pour la capture. Markdown pour la copie durable.</h1>
+            <p class="hero-intro">
+              NotesBridge ajoute une couche d'édition professionnelle au-dessus d'Apple Notes et exporte un espace de travail Markdown local utile pour Obsidian, Git et l'IA.
+            </p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="https://github.com/peizh/NotesBridge/releases">
+                Télécharger
+              </a>
+              <a class="button button-secondary" href="#proof">
+                En savoir plus
+              </a>
+            </div>
+          </div>
+
+          <div class="hero-proof">
+            <div class="proof-panel proof-input">
+              <span class="proof-label">Dans Apple Notes</span>
+              <div class="note-canvas">
+                <p class="note-title">Planning hebdomadaire</p>
+                <p class="note-line">• Finaliser les notes de version</p>
+                <p class="note-line">• Revoir la <span class="note-link">Liste de lancement</span></p>
+                <div class="floating-tools">
+                  <span>H1</span>
+                  <span>B</span>
+                  <span>I</span>
+                  <span>S</span>
+                </div>
+                <div class="slash-command">
+                  <span>/task</span>
+                  <small>élément de liste</small>
+                </div>
+              </div>
+            </div>
+            <div class="proof-panel proof-output">
+              <span class="proof-label">Sur disque (Markdown)</span>
+              <div class="file-stack">
+                <div class="file-tree">
+                  <span>Vault/</span>
+                  <span>&nbsp;&nbsp;Work/</span>
+                  <span>&nbsp;&nbsp;&nbsp;&nbsp;Weekly planning.md</span>
+                </div>
+                <pre><code># Planning hebdo
+
+- Finaliser notes
+- Revoir [[Liste lancement]]</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section proof" id="proof">
+          <div class="section-heading">
+            <p class="eyebrow">Capacités</p>
+            <h2>Un outil au-dessus, un coffre durable sur disque.</h2>
+          </div>
+
+          <div class="proof-columns">
+            <article class="proof-column">
+              <p class="column-kicker">Couche d'édition</p>
+              <h3>Édition professionnelle sur macOS.</h3>
+              <ul>
+                <li>Slash commands pour un formatage instantané</li>
+                <li>Déclencheurs Markdown pour les listes</li>
+                <li>Barre d'outils flottante pour le style rapide</li>
+              </ul>
+            </article>
+
+            <article class="proof-column">
+              <p class="column-kicker">Sortie de synchronisation</p>
+              <h3>Espace local-first durable.</h3>
+              <ul>
+                <li>Structure de dossiers préservée</li>
+                <li>Pièces jointes natives exportées sur place</li>
+                <li>Front matter et liens internes conservés</li>
+              </ul>
+            </article>
+
+            <article class="proof-column">
+              <p class="column-kicker">Pour qui ?</p>
+              <h3>Conçu pour vos outils actuels.</h3>
+              <ul>
+                <li>Compagnon idéal pour vos coffres Obsidian</li>
+                <li>Versionnez vos notes avec Git</li>
+                <li>Traitez vos connaissances avec des agents IA</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="section workflow" id="workflow">
+          <div class="section-heading">
+            <p class="eyebrow">Flux de travail</p>
+            <h2>Simple à adopter. Difficile à perdre.</h2>
+          </div>
+
+          <ol class="workflow-rail">
+            <li>
+              <span class="step-index">01</span>
+              <div>
+                <h3>Connecter à Apple Notes</h3>
+                <p>
+                  Lancez le compagnon et accordez les permissions. NotesBridge lit votre base Apple Notes locale — aucun nuage requis.
+                </p>
+              </div>
+            </li>
+
+            <li>
+              <span class="step-index">02</span>
+              <div>
+                <h3>Définir la destination</h3>
+                <p>
+                  Choisissez un dossier local ou votre coffre Obsidian. NotesBridge mappera vos dossiers en une hiérarchie Markdown.
+                </p>
+              </div>
+            </li>
+
+            <li>
+              <span class="step-index">03</span>
+              <div>
+                <h3>Écrire & Synchroniser</h3>
+                <p>
+                  Utilisez nos outils pour écrire plus vite. Votre copie Markdown reste synchrone, prête pour l'automatisation.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </section>
+
+        <section class="section faq" id="faq">
+          <div class="section-heading">
+            <p class="eyebrow">Questions</p>
+            <h2>FAQ</h2>
+          </div>
+
+          <div class="faq-list">
+            <details open>
+              <summary>Est-ce un plugin dans Apple Notes ?</summary>
+              <p>
+                Non. Apple Notes n'a pas d'API de plugin. NotesBridge est une app compagnon séparée qui utilise les API d'accessibilité.
+              </p>
+            </details>
+
+            <details>
+              <summary>Est-ce que ça synchronise vers Apple Notes ?</summary>
+              <p>
+                Actuellement, la sync est unidirectionnelle : d'Apple Notes vers Markdown. Votre coffre local est l'archive de confiance.
+              </p>
+            </details>
+
+            <details>
+              <summary>Gère-t-il les pièces jointes ?</summary>
+              <p>
+                Oui. NotesBridge exporte les pièces jointes, scans et images dans un dossier <code>attachments</code> à côté de vos fichiers.
+              </p>
+            </details>
+
+            <details>
+              <summary>Pourquoi pas un export manuel ?</summary>
+              <p>
+                L'export manuel perd la structure. NotesBridge automatise tout, préserve la hiérarchie et gère les liens internes.
+              </p>
+            </details>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <div class="footer-copy">
+          <strong>NotesBridge</strong>
+          <p>
+            Le pont entre la capture Apple Notes et la durabilité du Markdown local.
+          </p>
+        </div>
+        <nav class="footer-links">
+          <a href="https://github.com/peizh/NotesBridge/releases">Versions</a>
+          <a href="https://github.com/peizh/NotesBridge">GitHub</a>
+          <a href="index.html">English</a>
+          <a href="index.zh-CN.html">简体中文</a>
+        </nav>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -227,8 +227,8 @@
           <a href="https://github.com/peizh/NotesBridge/releases">Releases</a>
           <a href="https://github.com/peizh/NotesBridge">GitHub</a>
           <a href="https://github.com/peizh/NotesBridge/blob/main/README.md">README</a>
-          <a href="https://github.com/peizh/NotesBridge/blob/main/README.zh-CN.md">简体中文</a>
-          <a href="https://github.com/peizh/NotesBridge/blob/main/README.fr.md">Français</a>
+          <a href="index.zh-CN.html">简体中文</a>
+          <a href="index.fr.html">Français</a>
         </nav>
       </footer>
     </div>

--- a/site/index.zh-CN.html
+++ b/site/index.zh-CN.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NotesBridge | 苹果笔记转 Markdown 桌面伴侣</title>
+    <meta
+      name="description"
+      content="NotesBridge 是一个原生 macOS 伴侣应用。它在 Apple Notes 之上提供行内编辑增强能力，并将笔记导出为可保存、搜索、版本管理、并可与 AI agents 协作的本地 Markdown 文件和文件夹。"
+    >
+    <meta name="theme-color" content="#fdfaf3">
+    <meta property="og:title" content="NotesBridge">
+    <meta
+      property="og:description"
+      content="Apple Notes 用于分享、记录。Markdown 用于专业使用。"
+    >
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://peizh.github.io/NotesBridge/index.zh-CN.html">
+    <meta
+      property="og:image"
+      content="https://peizh.github.io/NotesBridge/assets/notesbridge-social.svg"
+    >
+    <link rel="icon" href="./assets/notesbridge-app-icon.svg" type="image/svg+xml">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700;9..144,800&family=Manrope:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="NotesBridge 首页">
+          <img src="./assets/notesbridge-app-icon.svg" alt="NotesBridge 图标">
+          <span>NotesBridge</span>
+        </a>
+        <nav class="topnav" aria-label="主要导航">
+          <a href="#proof">功能</a>
+          <a href="#workflow">工作流</a>
+          <a href="#faq">常见问题</a>
+        </nav>
+        <a class="topbar-action" href="https://github.com/peizh/NotesBridge/releases">
+          下载
+        </a>
+      </header>
+
+      <main id="top">
+        <section class="hero">
+          <div class="hero-copy">
+            <p class="eyebrow">Apple Notes 的 macOS 伴侣应用</p>
+            <h1>Apple Notes 用于分享、记录。Markdown 用于专业使用。</h1>
+            <p class="hero-intro">
+              NotesBridge 在 Apple Notes 之上添加了专业编辑层，并支持导出一个在 Obsidian、Git 和 AI 工作流中持续可用的本地 Markdown 工作区。
+            </p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="https://github.com/peizh/NotesBridge/releases">
+                下载最新版本
+              </a>
+              <a class="button button-secondary" href="#proof">
+                了解更多
+              </a>
+            </div>
+          </div>
+
+          <div class="hero-proof">
+            <div class="proof-panel proof-input">
+              <span class="proof-label">在 Apple Notes 内部</span>
+              <div class="note-canvas">
+                <p class="note-title">每周计划</p>
+                <p class="note-line">• 完成发布说明</p>
+                <p class="note-line">• 查看 <span class="note-link">发布核对清单</span></p>
+                <div class="floating-tools">
+                  <span>H1</span>
+                  <span>B</span>
+                  <span>I</span>
+                  <span>S</span>
+                </div>
+                <div class="slash-command">
+                  <span>/task</span>
+                  <small>待办事项</small>
+                </div>
+              </div>
+            </div>
+            <div class="proof-panel proof-output">
+              <span class="proof-label">磁盘上的文件 (Markdown)</span>
+              <div class="file-stack">
+                <div class="file-tree">
+                  <span>Vault/</span>
+                  <span>&nbsp;&nbsp;Work/</span>
+                  <span>&nbsp;&nbsp;&nbsp;&nbsp;Weekly planning.md</span>
+                </div>
+                <pre><code># 每周计划
+
+- 完成发布说明
+- 查看 [[发布核对清单]]</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section proof" id="proof">
+          <div class="section-heading">
+            <p class="eyebrow">产品能力</p>
+            <h2>一个在之上增强，一个在之下归档。</h2>
+          </div>
+
+          <div class="proof-columns">
+            <article class="proof-column">
+              <p class="column-kicker">行内编辑增强</p>
+              <h3>在 macOS 上获得专业编辑体验。</h3>
+              <ul>
+                <li>Slash commands 瞬间完成格式设置</li>
+                <li>Markdown 触发器快速生成列表和结构</li>
+                <li>浮动工具栏实现文本快速选中样式设置</li>
+              </ul>
+            </article>
+
+            <article class="proof-column">
+              <p class="column-kicker">同步导出</p>
+              <h3>持久的、本地优先的工作空间。</h3>
+              <ul>
+                <li>文件夹结构被完整保留为真实目录</li>
+                <li>原生附件被同步导出到对应位置</li>
+                <li>保留 Front matter 元数据和内部链接</li>
+              </ul>
+            </article>
+
+            <article class="proof-column">
+              <p class="column-kicker">谁适合使用</p>
+              <h3>为您已有的工具而设计。</h3>
+              <ul>
+                <li>Obsidian 仓库的完美伴侣</li>
+                <li>使用 Git 为您的笔记进行版本控制</li>
+                <li>将您的知识库交给 AI agents 处理</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="section workflow" id="workflow">
+          <div class="section-heading">
+            <p class="eyebrow">工作流</p>
+            <h2>轻松上手，持久留存。</h2>
+          </div>
+
+          <ol class="workflow-rail">
+            <li>
+              <span class="step-index">01</span>
+              <div>
+                <h3>连接到 Apple Notes</h3>
+                <p>
+                  启动菜单栏应用并授予必要的权限。NotesBridge 直接读取您的本地 Apple Notes 数据库——无需经过云端中转。
+                </p>
+              </div>
+            </li>
+
+            <li>
+              <span class="step-index">02</span>
+              <div>
+                <h3>设置归档目录</h3>
+                <p>
+                  选择一个本地文件夹或您的 Obsidian 仓库。NotesBridge 会将您的 Apple Notes 文件夹映射为清晰、可搜索的 Markdown 层级。
+                </p>
+              </div>
+            </li>
+
+            <li>
+              <span class="step-index">03</span>
+              <div>
+                <h3>编写与同步</h3>
+                <p>
+                  使用我们的行内工具在 Apple Notes 中更快地记录。您的本地 Markdown 副本将保持同步，随时可供搜索、归档或自动化处理。
+                </p>
+              </div>
+            </li>
+          </ol>
+        </section>
+
+        <section class="section faq" id="faq">
+          <div class="section-heading">
+            <p class="eyebrow">常见问题</p>
+            <h2>Q&amp;A</h2>
+          </div>
+
+          <div class="faq-list">
+            <details open>
+              <summary>NotesBridge 是 Apple Notes 内部的插件吗？</summary>
+              <p>
+                不。Apple Notes 没有公开插件 API。NotesBridge 是一个独立的 macOS 伴侣应用，它使用辅助功能 (Accessibility) API 来提供行内编辑工具。
+              </p>
+            </details>
+
+            <details>
+              <summary>它支持反向同步到 Apple Notes 吗？</summary>
+              <p>
+                目前同步是单向的：Apple Notes 到 Markdown。这确保了您的本地仓库作为“可信归档”，同时允许您将 Apple Notes 作为主要的采集工具。
+              </p>
+            </details>
+
+            <details>
+              <summary>它能处理附件和图片吗？</summary>
+              <p>
+                可以。NotesBridge 会将 Apple Notes 的原生附件、扫描件和图片导出到 Markdown 文件旁边的 <code>attachments</code> 文件夹中，并保留它们的上下文。
+              </p>
+            </details>
+
+            <details>
+              <summary>为什么要用它而不是手动导出？</summary>
+              <p>
+                手动导出非常繁琐且会丢失层级结构。NotesBridge 实现了这一过程的自动化，保留了文件夹层级，处理了内部链接，并让您的 Markdown 仓库与您的记录保持同步。
+              </p>
+            </details>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <div class="footer-copy">
+          <strong>NotesBridge</strong>
+          <p>
+            在 Apple Notes 采集与本地 Markdown 归档之间搭建桥梁。
+          </p>
+        </div>
+        <nav class="footer-links">
+          <a href="https://github.com/peizh/NotesBridge/releases">Releases</a>
+          <a href="https://github.com/peizh/NotesBridge">GitHub</a>
+          <a href="index.html">English</a>
+          <a href="index.fr.html">Français</a>
+        </nav>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR implements localized versions of the landing page (Chinese and French) within the site/ directory and updates internal navigation to use these local pages instead of external GitHub READMEs.