### PR TITLE
Switch GitHub Pages to notesbridge.peizh.live

### DIFF
--- a/scripts/notesbridge.sh
+++ b/scripts/notesbridge.sh
@@ -179,7 +179,7 @@ run_bundle_command() {
     local sign_identity="-"
     local team_id=""
     local launch_after_build=0
-    local sparkle_feed_url="${NOTESBRIDGE_SPARKLE_FEED_URL:-https://peizh.github.io/NotesBridge/updates/appcast.xml}"
+    local sparkle_feed_url="${NOTESBRIDGE_SPARKLE_FEED_URL:-https://notesbridge.peizh.live/updates/appcast.xml}"
     local sparkle_public_ed_key="${NOTESBRIDGE_SPARKLE_PUBLIC_ED_KEY:-bN0AdWyNntmdvuNQNXa2pDP8peMGNfsbBcrXIBf60ys=}"
 
     while [[ $# -gt 0 ]]; do
@@ -566,7 +566,7 @@ run_notarize_command() {
 run_appcast_command() {
     local generate_appcast="${NOTESBRIDGE_GENERATE_APPCAST:-$ROOT_DIR/.build/artifacts/sparkle/Sparkle/bin/generate_appcast}"
     local github_repository_slug="${NOTESBRIDGE_GITHUB_REPOSITORY:-peizh/NotesBridge}"
-    local pages_base_url="${NOTESBRIDGE_PAGES_BASE_URL:-https://peizh.github.io/NotesBridge}"
+    local pages_base_url="${NOTESBRIDGE_PAGES_BASE_URL:-https://notesbridge.peizh.live}"
     local sparkle_private_ed_key="${SPARKLE_PRIVATE_ED_KEY:-${NOTESBRIDGE_SPARKLE_PRIVATE_ED_KEY:-}}"
     local version=""
     local archive_path=""

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+notesbridge.peizh.live

--- a/site/index.fr.html
+++ b/site/index.fr.html
@@ -15,10 +15,10 @@
       content="Apple Notes pour la capture. Markdown pour la copie durable."
     >
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://peizh.github.io/NotesBridge/index.fr.html">
+    <meta property="og:url" content="https://notesbridge.peizh.live/index.fr.html">
     <meta
       property="og:image"
-      content="https://peizh.github.io/NotesBridge/assets/notesbridge-social.svg"
+      content="https://notesbridge.peizh.live/assets/notesbridge-social.svg"
     >
     <link rel="icon" href="./assets/notesbridge-app-icon.svg" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/index.html
+++ b/site/index.html
@@ -15,10 +15,10 @@
       content="Keep Apple Notes for capture. Keep Markdown for the durable copy."
     >
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://peizh.github.io/NotesBridge/">
+    <meta property="og:url" content="https://notesbridge.peizh.live/">
     <meta
       property="og:image"
-      content="https://peizh.github.io/NotesBridge/assets/notesbridge-social.svg"
+      content="https://notesbridge.peizh.live/assets/notesbridge-social.svg"
     >
     <link rel="icon" href="./assets/notesbridge-app-icon.svg" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/index.zh-CN.html
+++ b/site/index.zh-CN.html
@@ -15,10 +15,10 @@
       content="Apple Notes 用于分享、记录。Markdown 用于专业使用。"
     >
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://peizh.github.io/NotesBridge/index.zh-CN.html">
+    <meta property="og:url" content="https://notesbridge.peizh.live/index.zh-CN.html">
     <meta
       property="og:image"
-      content="https://peizh.github.io/NotesBridge/assets/notesbridge-social.svg"
+      content="https://notesbridge.peizh.live/assets/notesbridge-social.svg"
     >
     <link rel="icon" href="./assets/notesbridge-app-icon.svg" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- add `site/CNAME` so GitHub Pages keeps the custom domain on every `gh-pages` publish
- switch the default Pages base URL and Sparkle feed URL to `https://notesbridge.peizh.live`
- update marketing site Open Graph URLs to the custom domain

## Validation
- `swift test`
- `xcodebuild -scheme NotesBridge -workspace .swiftpm/xcode/package.xcworkspace -destination 'platform=macOS' test`

## Notes
- GitHub Pages custom domain is already set to `notesbridge.peizh.live`
- Cloudflare still needs a `CNAME` record: `notesbridge -> peizh.github.io` (DNS only first)
- after DNS propagates, enable HTTPS enforcement in GitHub Pages if it is not enabled automatically