### PR TITLE
fix(site): ensure brand logo link stays on the current localized page

### DIFF
--- a/site/index.fr.html
+++ b/site/index.fr.html
@@ -32,7 +32,7 @@
   <body>
     <div class="page-shell">
       <header class="topbar">
-        <a class="brand" href="index.html" aria-label="Accueil NotesBridge">
+        <a class="brand" href="#top" aria-label="Accueil NotesBridge">
           <img src="./assets/notesbridge-app-icon.svg" alt="Icône NotesBridge">
           <span>NotesBridge</span>
         </a>

--- a/site/index.zh-CN.html
+++ b/site/index.zh-CN.html
@@ -32,7 +32,7 @@
   <body>
     <div class="page-shell">
       <header class="topbar">
-        <a class="brand" href="index.html" aria-label="NotesBridge 首页">
+        <a class="brand" href="#top" aria-label="NotesBridge 首页">
           <img src="./assets/notesbridge-app-icon.svg" alt="NotesBridge 图标">
           <span>NotesBridge</span>
         </a>


### PR DESCRIPTION
Addresses the PR comment from cubic-dev-ai[bot] in #15 by updating the logo link to #top in the localized pages.