### PR TITLE
Replace remaining GitHub Pages URLs with notesbridge.peizh.live

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -9,7 +9,7 @@
 
 ![NotesBridge social banner](./images/notesbridge-social.svg)
 
-Site web : [peizh.github.io/NotesBridge](https://peizh.github.io/NotesBridge/)
+Site web : [notesbridge.peizh.live](https://notesbridge.peizh.live/)
 
 NotesBridge est une application compagnon native macOS pour Apple Notes. Elle fonctionne comme une app de barre de menus, ajoute des améliorations d'édition en ligne au-dessus d'Apple Notes et exporte les notes vers des fichiers et dossiers Markdown locaux que vous pouvez conserver, rechercher, versionner et utiliser avec des agents IA.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ![NotesBridge social banner](./images/notesbridge-social.svg)
 
-Website: [peizh.github.io/NotesBridge](https://peizh.github.io/NotesBridge/)
+Website: [notesbridge.peizh.live](https://notesbridge.peizh.live/)
 
 NotesBridge is a native macOS companion for Apple Notes. It runs as a menu bar app, adds inline editing enhancements on top of Apple Notes, and exports notes into local Markdown files and folders you can keep, search, version, and use with AI agents.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 
 ![NotesBridge social banner](./images/notesbridge-social.svg)
 
-网站: [peizh.github.io/NotesBridge](https://peizh.github.io/NotesBridge/)
+网站: [notesbridge.peizh.live](https://notesbridge.peizh.live/)
 
 NotesBridge 是一个面向 Apple Notes 的原生 macOS 伴侣应用。它以菜单栏应用的形式运行，在 Apple Notes 之上提供行内编辑增强能力，并将笔记导出为可保存、搜索、版本管理、并可与 AI agents 协作的本地 Markdown 文件和文件夹。
 

--- a/docs/sparkle-key-setup.md
+++ b/docs/sparkle-key-setup.md
@@ -135,7 +135,7 @@ After updating the embedded public key and setting the private-key secret:
 4. verify the feed URL returns `200`:
 
 ```bash
-curl -I -L https://peizh.github.io/NotesBridge/updates/appcast.xml
+curl -I -L https://notesbridge.peizh.live/updates/appcast.xml
 ```
 
 5. verify `gh-pages` exists:


### PR DESCRIPTION
## Summary
- replace the remaining `https://peizh.github.io/NotesBridge` links in the English, Chinese, and French READMEs
- update the Sparkle key setup doc to use `https://notesbridge.peizh.live/updates/appcast.xml`
- leave unrelated local handoff files untouched

## Validation
- `swift test`
- `xcodebuild -scheme NotesBridge -workspace .swiftpm/xcode/package.xcworkspace -destination 'platform=macOS' test`

## Notes
- tracked files now have no remaining `peizh.github.io/NotesBridge` URLs
- bundled app was relaunched after each passing test command per repo workflow