### PR TITLE
Feature: Unify slash menu and inline menu interaction model (#10)

### DIFF
--- a/Sources/NotesBridge/App/AppModel.swift
+++ b/Sources/NotesBridge/App/AppModel.swift
@@ -84,8 +84,8 @@ final class AppModel: ObservableObject {
             refreshAppleNotesDataAccessStatus()
             scheduleAutomaticSyncIfNeeded()
             formattingBarController.update(
-                selectionContext: selectionContext,
-                availability: interactionAvailability,
+                selectionContext: interactionState.selectionContext,
+                availability: interactionState.availability,
                 commands: visibleInlineToolbarCommands,
                 localization: localization
             )
@@ -93,9 +93,8 @@ final class AppModel: ObservableObject {
     }
 
     @Published private(set) var buildFlavor: BuildFlavor
-    @Published private(set) var interactionAvailability: InteractionAvailability
+    @Published private(set) var interactionState: InteractionState
     @Published private(set) var folderSummaries: [AppleNotesFolder] = []
-    @Published private(set) var selectionContext: SelectionContext?
     @Published private(set) var isRefreshingFolders = false
     @Published private(set) var isSyncing = false
     @Published private(set) var menuBarSyncFrameIndex = 0
@@ -188,7 +187,10 @@ final class AppModel: ObservableObject {
         self.slashCommandEngine = slashCommandEngine
         self.formattingBarController = formattingBarController
         self.statusObserver = statusObserver
-        self.interactionAvailability = .default(for: resolvedBuildFlavor)
+        self.interactionState = InteractionState(
+            selectionContext: nil,
+            availability: .default(for: resolvedBuildFlavor)
+        )
         self.slashCommandEngine.onKeyboardNavigationAvailabilityChanged = { [weak self] isAvailable in
             self?.slashKeyboardNavigationAvailable = isAvailable
         }
@@ -306,7 +308,7 @@ final class AppModel: ObservableObject {
     }
 
     var selectionSummary: String {
-        guard let selectionContext, selectionContext.hasSelection else {
+        guard let selectionContext = interactionState.selectionContext, selectionContext.hasSelection else {
             return t("No text selected")
         }
 
@@ -330,10 +332,10 @@ final class AppModel: ObservableObject {
         if isSyncing {
             return "arrow.triangle.2.circlepath"
         }
-        if interactionAvailability.canShowFormattingBar {
+        if interactionState.availability.canShowFormattingBar {
             return "text.cursor"
         }
-        if interactionAvailability.supportsInlineEnhancements && !interactionAvailability.accessibilityGranted {
+        if interactionState.availability.supportsInlineEnhancements && !interactionState.availability.accessibilityGranted {
             return "exclamationmark.circle"
         }
         return "note.text.badge.plus"
@@ -352,16 +354,16 @@ final class AppModel: ObservableObject {
         if visibleSlashCommandCatalog.entries.isEmpty {
             return t("No slash commands are enabled in Settings.")
         }
-        if !interactionAvailability.accessibilityGranted {
+        if !interactionState.availability.accessibilityGranted {
             if isRunningBundledApp {
                 return t("Accessibility permission is required for slash commands. If NotesBridge is already checked in Accessibility, remove and re-add the current app bundle once.")
             }
             return t("Accessibility permission is required for slash commands.")
         }
-        if !interactionAvailability.notesIsFrontmost {
+        if !interactionState.availability.notesIsFrontmost {
             return t("Bring Apple Notes to the front to use slash commands.")
         }
-        if !interactionAvailability.editableFocus {
+        if !interactionState.availability.editableFocus {
             return t("Focus the Apple Notes editor to use slash commands.")
         }
         if !slashKeyboardNavigationAvailable {
@@ -374,10 +376,10 @@ final class AppModel: ObservableObject {
         if !buildFlavor.supportsInlineEnhancements {
             return t("Inline enhancements are disabled in the Mac App Store build.")
         }
-        if isRunningBundledApp && !interactionAvailability.accessibilityGranted {
+        if isRunningBundledApp && !interactionState.availability.accessibilityGranted {
             return t("Grant Accessibility to NotesBridge. If it is already checked, remove and re-add the current app bundle once.")
         }
-        return t(interactionAvailability.summary)
+        return t(interactionState.availability.summary)
     }
 
     var attachmentStorageBasePath: String {
@@ -432,7 +434,7 @@ final class AppModel: ObservableObject {
         statusMessage = t("Requesting Accessibility permission for NotesBridge...")
         permissionsManager.requestAccessibilityPermission()
         notesContextMonitor.updateSettings(settings)
-        if interactionAvailability.accessibilityGranted {
+        if interactionState.availability.accessibilityGranted {
             statusMessage = t("Accessibility is already granted for NotesBridge.")
         } else if isRunningBundledApp {
             _ = permissionsManager.openAccessibilitySettings()
@@ -461,7 +463,7 @@ final class AppModel: ObservableObject {
         statusMessage = t("Requesting Input Monitoring permission for slash menu keyboard navigation...")
         permissionsManager.requestInputMonitoringPermission()
         notesContextMonitor.updateSettings(settings)
-        if interactionAvailability.inputMonitoringGranted {
+        if interactionState.availability.inputMonitoringGranted {
             statusMessage = t("Input Monitoring is already granted for NotesBridge.")
         } else {
             _ = permissionsManager.openInputMonitoringSettings()
@@ -1262,28 +1264,14 @@ final class AppModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        notesContextMonitor.$availability
+        notesContextMonitor.$state
             .receive(on: RunLoop.main)
-            .sink { [weak self] availability in
+            .sink { [weak self] state in
                 guard let self else { return }
-                self.interactionAvailability = availability
+                self.interactionState = state
                 self.formattingBarController.update(
-                    selectionContext: self.selectionContext,
-                    availability: availability,
-                    commands: self.visibleInlineToolbarCommands,
-                    localization: self.localization
-                )
-            }
-            .store(in: &cancellables)
-
-        notesContextMonitor.$selectionContext
-            .receive(on: RunLoop.main)
-            .sink { [weak self] selectionContext in
-                guard let self else { return }
-                self.selectionContext = selectionContext
-                self.formattingBarController.update(
-                    selectionContext: selectionContext,
-                    availability: self.interactionAvailability,
+                    selectionContext: state.selectionContext,
+                    availability: state.availability,
                     commands: self.visibleInlineToolbarCommands,
                     localization: self.localization
                 )
@@ -1336,7 +1324,7 @@ final class AppModel: ObservableObject {
         guard buildFlavor.supportsInlineEnhancements,
               settings.enableInlineEnhancements,
               isRunningBundledApp,
-              !interactionAvailability.accessibilityGranted
+              !interactionState.availability.accessibilityGranted
         else {
             return
         }
@@ -1346,7 +1334,7 @@ final class AppModel: ObservableObject {
                   self.isRunningBundledApp,
                   self.buildFlavor.supportsInlineEnhancements,
                   self.settings.enableInlineEnhancements,
-                  !self.interactionAvailability.accessibilityGranted
+                  !self.interactionState.availability.accessibilityGranted
             else {
                 return
             }

--- a/Sources/NotesBridge/Interaction/ContextualSurfaceController.swift
+++ b/Sources/NotesBridge/Interaction/ContextualSurfaceController.swift
@@ -1,0 +1,185 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+class ContextualSurfaceController {
+    private(set) var panel: NSPanel?
+    private(set) var hostingController: NSHostingController<AnyView>?
+    private var lastFrame: CGRect?
+    private var lastAnchorRect: CGRect?
+
+    func update<Content: View>(
+        rootView: Content,
+        anchorRect: CGRect?,
+        size: CGSize,
+        preferredEdge: NSRectEdge
+    ) {
+        let panel = ensurePanel(with: rootView)
+        if let hostingController {
+            hostingController.rootView = AnyView(rootView)
+            hostingController.view.layoutSubtreeIfNeeded()
+            panel.contentView?.layoutSubtreeIfNeeded()
+        }
+
+        let appKitAnchorRect = anchorRect.map(convertAccessibilityRectToAppKit) ?? CGRect(origin: NSEvent.mouseLocation, size: .zero)
+        let targetScreen = screen(containing: appKitAnchorRect) ?? NSScreen.main
+        let visibleFrame = targetScreen?.visibleFrame ?? NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+            partialResult.union(screen.visibleFrame)
+        }
+
+        let origin = bestPanelOrigin(for: appKitAnchorRect, panelSize: size, visibleFrame: visibleFrame, preferredEdge: preferredEdge)
+        let targetFrame = CGRect(origin: origin, size: size)
+
+        if lastFrame.map({ !approximatelyEqual($0, targetFrame) }) ?? true {
+            panel.setFrame(targetFrame, display: true)
+            lastFrame = targetFrame
+        }
+
+        if !panel.isVisible {
+            if panel.becomesKeyOnlyIfNeeded {
+                panel.makeKeyAndOrderFront(nil)
+            } else {
+                panel.orderFrontRegardless()
+            }
+        } else if !panel.isKeyWindow && panel.becomesKeyOnlyIfNeeded {
+             panel.makeKey()
+        }
+    }
+
+    func hide() {
+        panel?.orderOut(nil)
+        lastFrame = nil
+        lastAnchorRect = nil
+    }
+
+    var isVisible: Bool {
+        panel?.isVisible == true
+    }
+
+    var isKeyWindow: Bool {
+        panel?.isKeyWindow == true
+    }
+
+    func makePanel(contentRect: CGRect) -> NSPanel {
+        let panel = ContextualSurfacePanel(
+            contentRect: contentRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isFloatingPanel = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+        panel.hasShadow = true
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hidesOnDeactivate = false
+        return panel
+    }
+
+    private func ensurePanel<Content: View>(with rootView: Content) -> NSPanel {
+        if let panel {
+            return panel
+        }
+
+        let hostingController = NSHostingController(rootView: AnyView(rootView))
+        let panel = makePanel(contentRect: CGRect(origin: .zero, size: hostingController.view.fittingSize))
+        panel.contentViewController = hostingController
+        panel.contentView?.layoutSubtreeIfNeeded()
+
+        self.panel = panel
+        self.hostingController = hostingController
+        return panel
+    }
+
+    func convertAccessibilityRectToAppKit(_ rect: CGRect) -> CGRect {
+        let desktopFrame = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+            partialResult.union(screen.frame)
+        }
+        guard !desktopFrame.isNull else { return rect }
+
+        return CGRect(
+            x: rect.origin.x,
+            y: desktopFrame.maxY - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+
+    func screen(containing rect: CGRect) -> NSScreen? {
+        let anchorPoint = CGPoint(x: rect.midX, y: rect.midY)
+        return NSScreen.screens.first(where: { $0.frame.contains(anchorPoint) })
+    }
+
+    func bestPanelOrigin(
+        for anchorRect: CGRect,
+        panelSize: CGSize,
+        visibleFrame: CGRect,
+        preferredEdge: NSRectEdge
+    ) -> CGPoint {
+        let horizontalPadding: CGFloat = FloatingToolPaletteStyle.surfaceHorizontalPadding
+        let verticalPadding: CGFloat = preferredEdge == .maxY ? 10 : 6
+
+        let preferredAboveY = anchorRect.maxY + verticalPadding
+        let preferredBelowY = anchorRect.minY - panelSize.height - verticalPadding
+
+        let aboveFits = preferredAboveY + panelSize.height <= visibleFrame.maxY
+        let belowFits = preferredBelowY >= visibleFrame.minY
+
+        let unclampedX: CGFloat
+        if preferredEdge == .maxY {
+            unclampedX = anchorRect.midX - (panelSize.width / 2)
+        } else {
+            unclampedX = anchorRect.minX - 6
+        }
+
+        let x = min(
+            max(unclampedX, visibleFrame.minX + horizontalPadding),
+            visibleFrame.maxX - panelSize.width - horizontalPadding
+        )
+
+        let chosenY: CGFloat
+        if preferredEdge == .maxY {
+            if aboveFits {
+                chosenY = preferredAboveY
+            } else if belowFits {
+                chosenY = preferredBelowY
+            } else {
+                chosenY = min(
+                    max(preferredAboveY, visibleFrame.minY + verticalPadding),
+                    visibleFrame.maxY - panelSize.height - verticalPadding
+                )
+            }
+        } else {
+            if belowFits {
+                chosenY = preferredBelowY
+            } else if aboveFits {
+                chosenY = preferredAboveY
+            } else {
+                chosenY = min(
+                    max(preferredBelowY, visibleFrame.minY + verticalPadding),
+                    visibleFrame.maxY - panelSize.height - verticalPadding
+                )
+            }
+        }
+
+        return CGPoint(x: x, y: chosenY)
+    }
+
+    func approximatelyEqual(_ lhs: CGRect, _ rhs: CGRect, tolerance: CGFloat = FloatingToolPaletteStyle.jitterTolerance) -> Bool {
+        abs(lhs.origin.x - rhs.origin.x) <= tolerance
+            && abs(lhs.origin.y - rhs.origin.y) <= tolerance
+            && abs(lhs.size.width - rhs.size.width) <= tolerance
+            && abs(lhs.size.height - rhs.size.height) <= tolerance
+    }
+}
+
+class ContextualSurfacePanel: NSPanel {
+    override var canBecomeKey: Bool {
+        true
+    }
+
+    override var canBecomeMain: Bool {
+        false
+    }
+}

--- a/Sources/NotesBridge/Interaction/FloatingFormattingBarController.swift
+++ b/Sources/NotesBridge/Interaction/FloatingFormattingBarController.swift
@@ -2,10 +2,8 @@ import AppKit
 import SwiftUI
 
 @MainActor
-final class FloatingFormattingBarController {
+final class FloatingFormattingBarController: ContextualSurfaceController {
     private let executor: FormattingCommandExecutor
-    private var panel: NSPanel?
-    private var hostingController: NSHostingController<FormattingBarView>?
 
     init(executor: FormattingCommandExecutor) {
         self.executor = executor
@@ -26,105 +24,12 @@ final class FloatingFormattingBarController {
             return
         }
 
-        let anchorRect = selectionContext.selectionRect.map(convertAccessibilityRectToAppKit) ?? CGRect(origin: NSEvent.mouseLocation, size: .zero)
-        let panel = ensurePanel()
-        hostingController?.rootView = FormattingBarView(commands: commands, localization: localization) { [weak self] command in
+        let rootView = FormattingBarView(commands: commands, localization: localization) { [weak self] command in
             self?.executor.perform(command)
             self?.hide()
         }
 
         let size = hostingController?.view.fittingSize ?? CGSize(width: 420, height: 46)
-        let targetScreen = screen(containing: anchorRect) ?? NSScreen.main
-        let visibleFrame = targetScreen?.visibleFrame ?? NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
-            partialResult.union(screen.visibleFrame)
-        }
-        let origin = bestPanelOrigin(for: anchorRect, panelSize: size, visibleFrame: visibleFrame)
-
-        panel.setFrame(CGRect(origin: origin, size: size), display: true)
-        panel.orderFrontRegardless()
-    }
-
-    func hide() {
-        panel?.orderOut(nil)
-    }
-
-    private func ensurePanel() -> NSPanel {
-        if let panel {
-            return panel
-        }
-
-        let rootView = FormattingBarView(commands: [], localization: AppLocalization(language: .system)) { [weak self] command in
-            self?.executor.perform(command)
-            self?.hide()
-        }
-        let hostingController = NSHostingController(rootView: rootView)
-        let panel = NSPanel(
-            contentRect: CGRect(x: 0, y: 0, width: 420, height: 46),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
-        )
-        panel.contentViewController = hostingController
-        panel.level = .floating
-        panel.isFloatingPanel = true
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
-        panel.hasShadow = true
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.hidesOnDeactivate = false
-        panel.contentView?.layoutSubtreeIfNeeded()
-
-        self.panel = panel
-        self.hostingController = hostingController
-        return panel
-    }
-
-    private func convertAccessibilityRectToAppKit(_ rect: CGRect) -> CGRect {
-        let desktopFrame = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
-            partialResult.union(screen.frame)
-        }
-        guard !desktopFrame.isNull else { return rect }
-
-        return CGRect(
-            x: rect.origin.x,
-            y: desktopFrame.maxY - rect.origin.y - rect.height,
-            width: rect.width,
-            height: rect.height
-        )
-    }
-
-    private func screen(containing rect: CGRect) -> NSScreen? {
-        let anchorPoint = CGPoint(x: rect.midX, y: rect.midY)
-        return NSScreen.screens.first(where: { $0.frame.contains(anchorPoint) })
-    }
-
-    private func bestPanelOrigin(for anchorRect: CGRect, panelSize: CGSize, visibleFrame: CGRect) -> CGPoint {
-        let horizontalPadding: CGFloat = 8
-        let verticalPadding: CGFloat = 10
-        let preferredAboveY = anchorRect.maxY + verticalPadding
-        let preferredBelowY = anchorRect.minY - panelSize.height - verticalPadding
-
-        let aboveFits = preferredAboveY + panelSize.height <= visibleFrame.maxY
-        let belowFits = preferredBelowY >= visibleFrame.minY
-
-        let unclampedX = anchorRect.midX - (panelSize.width / 2)
-        let x = min(
-            max(unclampedX, visibleFrame.minX + horizontalPadding),
-            visibleFrame.maxX - panelSize.width - horizontalPadding
-        )
-
-        let chosenY: CGFloat
-        if aboveFits {
-            chosenY = preferredAboveY
-        } else if belowFits {
-            chosenY = preferredBelowY
-        } else {
-            chosenY = min(
-                max(preferredAboveY, visibleFrame.minY + verticalPadding),
-                visibleFrame.maxY - panelSize.height - verticalPadding
-            )
-        }
-
-        return CGPoint(x: x, y: chosenY)
+        update(rootView: rootView, anchorRect: selectionContext.selectionRect, size: size, preferredEdge: .maxY)
     }
 }

--- a/Sources/NotesBridge/Interaction/FloatingToolPaletteStyle.swift
+++ b/Sources/NotesBridge/Interaction/FloatingToolPaletteStyle.swift
@@ -16,6 +16,9 @@ enum FloatingToolPaletteStyle {
     static let rowVerticalPadding: CGFloat = 5
     static let rowSpacing: CGFloat = 6
     static let rowSelectionOpacity: CGFloat = 0.15
+
+    static let surfaceHorizontalPadding: CGFloat = 8
+    static let jitterTolerance: CGFloat = 0.5
 }
 
 struct FloatingToolPaletteIcon: View {

--- a/Sources/NotesBridge/Interaction/MarkdownTriggerEngine.swift
+++ b/Sources/NotesBridge/Interaction/MarkdownTriggerEngine.swift
@@ -33,7 +33,7 @@ final class MarkdownTriggerEngine {
     }
 
     private func evaluatePendingTrigger() {
-        guard contextMonitor.availability.canRunMarkdownTriggers,
+        guard contextMonitor.state.availability.canRunMarkdownTriggers,
               let snapshot = contextMonitor.editingSnapshot(includeValue: true),
               snapshot.selectedRange.length == 0,
               let value = snapshot.value

--- a/Sources/NotesBridge/Interaction/NotesContextMonitor.swift
+++ b/Sources/NotesBridge/Interaction/NotesContextMonitor.swift
@@ -2,20 +2,28 @@ import AppKit
 import ApplicationServices
 import Foundation
 
+struct InteractionState: Equatable {
+    var selectionContext: SelectionContext?
+    var availability: InteractionAvailability
+}
+
 @MainActor
 final class NotesContextMonitor: ObservableObject {
-    @Published private(set) var selectionContext: SelectionContext?
-    @Published private(set) var availability: InteractionAvailability
+    @Published private(set) var state: InteractionState
 
     private let permissionsManager: PermissionsManager
     private var settings: AppSettings
     private var timer: Timer?
     private let notesBundleIdentifier = "com.apple.Notes"
+    private var lastEditableElement: AXUIElement?
 
     init(buildFlavor: BuildFlavor, permissionsManager: PermissionsManager, settings: AppSettings) {
         self.permissionsManager = permissionsManager
         self.settings = settings
-        self.availability = .default(for: buildFlavor)
+        self.state = InteractionState(
+            selectionContext: nil,
+            availability: .default(for: buildFlavor)
+        )
     }
 
     func start() {
@@ -42,7 +50,7 @@ final class NotesContextMonitor: ObservableObject {
     }
 
     func editingSnapshot(includeValue: Bool) -> EditingContext? {
-        guard availability.supportsInlineEnhancements,
+        guard state.availability.supportsInlineEnhancements,
               permissionsManager.accessibilityGranted,
               isNotesFrontmost,
               let focusedElement = focusedUIElement,
@@ -55,7 +63,7 @@ final class NotesContextMonitor: ObservableObject {
     }
 
     func editingSnapshot(from element: AXUIElement, includeValue: Bool) -> EditingContext? {
-        guard availability.supportsInlineEnhancements,
+        guard state.availability.supportsInlineEnhancements,
               permissionsManager.accessibilityGranted,
               isEditable(element: element)
         else {
@@ -89,33 +97,59 @@ final class NotesContextMonitor: ObservableObject {
     private func refreshNow() {
         permissionsManager.refresh()
 
-        let notesIsFrontmost = isNotesFrontmost
+        let frontmostApp = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        let isNotesAppFrontmost = frontmostApp == notesBundleIdentifier
+        let isNotesBridgeFrontmost = frontmostApp == Bundle.main.bundleIdentifier
+        let notesIsFrontmost = isNotesAppFrontmost || isNotesBridgeFrontmost
+        
         let accessibilityGranted = permissionsManager.accessibilityGranted
         let inputMonitoringGranted = permissionsManager.inputMonitoringGranted
         var editableFocus = false
         var nextSelectionContext: SelectionContext?
 
-        if availability.supportsInlineEnhancements,
+        if state.availability.buildFlavor.supportsInlineEnhancements,
            accessibilityGranted,
-           notesIsFrontmost,
-           let snapshot = editingSnapshot(includeValue: false)
+           notesIsFrontmost
         {
-            editableFocus = true
+            let isOurPanelKey = NSApp.windows.contains(where: { $0.isKeyWindow })
+            
+            if isNotesBridgeFrontmost || isOurPanelKey {
+                // If our panel is frontmost or has key focus, Apple Notes is inactive. Accessibility reads for selection bounds
+                // might be unstable or empty. Freeze the state to prevent flickering.
+                editableFocus = state.availability.editableFocus
+                nextSelectionContext = state.selectionContext
+            } else {
+                var elementToUse = focusedUIElement
+                
+                if elementToUse == nil || !isEditable(element: elementToUse!) {
+                    elementToUse = lastEditableElement
+                }
 
-            if snapshot.selectedRange.length > 0 {
-                nextSelectionContext = SelectionContext(
-                    selectedText: snapshot.selectedText,
-                    selectedRange: snapshot.selectedRange,
-                    selectionRect: snapshot.selectionRect,
-                    noteTitle: nil,
-                    folderName: nil
-                )
+                if let elementToUse, isEditable(element: elementToUse) {
+                    if let snapshot = snapshot(for: elementToUse, includeValue: false) {
+                        editableFocus = true
+                        lastEditableElement = elementToUse
+
+                        if snapshot.selectedRange.length > 0 {
+                            nextSelectionContext = SelectionContext(
+                                selectedText: snapshot.selectedText,
+                                selectedRange: snapshot.selectedRange,
+                                selectionRect: snapshot.selectionRect,
+                                noteTitle: nil,
+                                folderName: nil
+                            )
+                        }
+                    }
+                }
             }
         }
 
-        selectionContext = nextSelectionContext
-        availability = InteractionAvailability(
-            buildFlavor: availability.buildFlavor,
+        if !notesIsFrontmost {
+            lastEditableElement = nil
+        }
+
+        let nextAvailability = InteractionAvailability(
+            buildFlavor: state.availability.buildFlavor,
             accessibilityGranted: accessibilityGranted,
             inputMonitoringGranted: inputMonitoringGranted,
             notesIsFrontmost: notesIsFrontmost,
@@ -125,10 +159,20 @@ final class NotesContextMonitor: ObservableObject {
             markdownTriggersEnabled: settings.enableMarkdownTriggers,
             slashCommandsEnabled: settings.enableSlashCommands
         )
+
+        let nextState = InteractionState(
+            selectionContext: nextSelectionContext,
+            availability: nextAvailability
+        )
+
+        if state != nextState {
+            state = nextState
+        }
     }
 
     private var isNotesFrontmost: Bool {
-        NSWorkspace.shared.frontmostApplication?.bundleIdentifier == notesBundleIdentifier
+        let frontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        return frontmost == notesBundleIdentifier || frontmost == Bundle.main.bundleIdentifier
     }
 
     private var focusedUIElement: AXUIElement? {

--- a/Sources/NotesBridge/Interaction/SlashCommandEngine.swift
+++ b/Sources/NotesBridge/Interaction/SlashCommandEngine.swift
@@ -77,8 +77,8 @@ final class SlashCommandEngine {
             snapshot = contextMonitor.editingSnapshot(from: currentEditingContext.element, includeValue: true)
             recordDiagnostic("slash panel owns keyboard focus; refreshing from cached notes editor")
         } else {
-            guard contextMonitor.availability.canRunSlashCommands else {
-                recordDiagnostic("snapshot unavailable for slash evaluation")
+            guard contextMonitor.state.availability.canRunSlashCommands else {
+                recordDiagnostic("slash panel unavailable for slash evaluation")
                 lastCommittedSignature = nil
                 hideMenu()
                 return

--- a/Sources/NotesBridge/Interaction/SlashCommandMenuController.swift
+++ b/Sources/NotesBridge/Interaction/SlashCommandMenuController.swift
@@ -2,17 +2,15 @@ import AppKit
 import SwiftUI
 
 @MainActor
-final class SlashCommandMenuController {
+final class SlashCommandMenuController: ContextualSurfaceController {
     private let onHoverIndex: (Int) -> Void
     private let onSelectIndex: (Int) -> Void
     private let onFrameUpdated: (CGRect) -> Void
     private let onKeyboardAction: (SlashCommandKeyboardAction) -> Void
     private let onPassthroughKeyDown: (NSEvent) -> Void
-    private var panel: NSPanel?
-    private var hostingController: NSHostingController<SlashCommandMenuView>?
+
     private var lastEntries: [SlashCommandEntry] = []
     private var lastSelectedIndex = 0
-    private var lastFrame: CGRect?
     private var lastLocalization = AppLocalization(language: .system)
 
     init(
@@ -30,12 +28,8 @@ final class SlashCommandMenuController {
     }
 
     func update(entries: [SlashCommandEntry], localization: AppLocalization, selectedIndex: Int, anchorRect: CGRect?) {
-        let panel = ensurePanel()
         let contentChanged = lastEntries != entries || lastSelectedIndex != selectedIndex || lastLocalization.language != localization.language
         if contentChanged {
-            hostingController?.rootView = rootView(entries: entries, localization: localization, selectedIndex: selectedIndex)
-            hostingController?.view.layoutSubtreeIfNeeded()
-            panel.contentView?.layoutSubtreeIfNeeded()
             lastEntries = entries
             lastSelectedIndex = selectedIndex
             lastLocalization = localization
@@ -46,55 +40,32 @@ final class SlashCommandMenuController {
             width: max(260, fittedSize.width),
             height: max(44, fittedSize.height)
         )
-        let anchorRect = anchorRect.map(convertAccessibilityRectToAppKit) ?? CGRect(origin: NSEvent.mouseLocation, size: .zero)
-        let targetScreen = screen(containing: anchorRect) ?? NSScreen.main
-        let visibleFrame = targetScreen?.visibleFrame ?? NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
-            partialResult.union(screen.visibleFrame)
-        }
-        let origin = bestPanelOrigin(for: anchorRect, panelSize: size, visibleFrame: visibleFrame)
-        let targetFrame = CGRect(origin: origin, size: size)
 
-        if lastFrame.map({ !approximatelyEqual($0, targetFrame) }) ?? true {
-            panel.setFrame(targetFrame, display: true)
-            lastFrame = targetFrame
-            onFrameUpdated(panel.frame)
-        }
+        let rootView = SlashCommandMenuView(
+            entries: entries,
+            localization: localization,
+            selectedIndex: selectedIndex,
+            onHoverIndex: onHoverIndex,
+            onSelectIndex: onSelectIndex
+        )
 
-        if !panel.isVisible {
-            panel.makeKeyAndOrderFront(nil)
-        } else if !panel.isKeyWindow {
-            panel.makeKey()
+        let oldFrame = panel?.frame
+        update(rootView: rootView, anchorRect: anchorRect, size: size, preferredEdge: .minY)
+
+        if let newFrame = panel?.frame, oldFrame != newFrame {
+            onFrameUpdated(newFrame)
         }
     }
 
-    func hide() {
-        panel?.orderOut(nil)
-        lastFrame = nil
-    }
-
-    var isVisible: Bool {
-        panel?.isVisible == true
-    }
-
-    var isKeyWindow: Bool {
-        panel?.isKeyWindow == true
-    }
-
-    private func ensurePanel() -> NSPanel {
-        if let panel {
-            return panel
-        }
-
-        let hostingController = NSHostingController(rootView: rootView(entries: [], localization: lastLocalization, selectedIndex: 0))
+    override func makePanel(contentRect: CGRect) -> NSPanel {
         let panel = SlashCommandPanel(
-            contentRect: CGRect(x: 0, y: 0, width: 260, height: 88),
+            contentRect: contentRect,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false,
             onKeyboardAction: onKeyboardAction,
             onPassthroughKeyDown: onPassthroughKeyDown
         )
-        panel.contentViewController = hostingController
         panel.level = .floating
         panel.isFloatingPanel = true
         panel.becomesKeyOnlyIfNeeded = true
@@ -103,80 +74,11 @@ final class SlashCommandMenuController {
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hidesOnDeactivate = false
-        panel.contentView?.layoutSubtreeIfNeeded()
-
-        self.panel = panel
-        self.hostingController = hostingController
         return panel
-    }
-
-    private func rootView(entries: [SlashCommandEntry], localization: AppLocalization, selectedIndex: Int) -> SlashCommandMenuView {
-        SlashCommandMenuView(
-            entries: entries,
-            localization: localization,
-            selectedIndex: selectedIndex,
-            onHoverIndex: onHoverIndex,
-            onSelectIndex: onSelectIndex
-        )
-    }
-
-    private func convertAccessibilityRectToAppKit(_ rect: CGRect) -> CGRect {
-        let desktopFrame = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
-            partialResult.union(screen.frame)
-        }
-        guard !desktopFrame.isNull else { return rect }
-
-        return CGRect(
-            x: rect.origin.x,
-            y: desktopFrame.maxY - rect.origin.y - rect.height,
-            width: rect.width,
-            height: rect.height
-        )
-    }
-
-    private func screen(containing rect: CGRect) -> NSScreen? {
-        let anchorPoint = CGPoint(x: rect.midX, y: rect.midY)
-        return NSScreen.screens.first(where: { $0.frame.contains(anchorPoint) })
-    }
-
-    private func bestPanelOrigin(for anchorRect: CGRect, panelSize: CGSize, visibleFrame: CGRect) -> CGPoint {
-        let horizontalPadding: CGFloat = 8
-        let verticalPadding: CGFloat = 6
-        let preferredBelowY = anchorRect.minY - panelSize.height - verticalPadding
-        let preferredAboveY = anchorRect.maxY + verticalPadding
-
-        let belowFits = preferredBelowY >= visibleFrame.minY
-        let aboveFits = preferredAboveY + panelSize.height <= visibleFrame.maxY
-
-        let x = min(
-            max(anchorRect.minX - 6, visibleFrame.minX + horizontalPadding),
-            visibleFrame.maxX - panelSize.width - horizontalPadding
-        )
-
-        let chosenY: CGFloat
-        if belowFits {
-            chosenY = preferredBelowY
-        } else if aboveFits {
-            chosenY = preferredAboveY
-        } else {
-            chosenY = min(
-                max(preferredBelowY, visibleFrame.minY + verticalPadding),
-                visibleFrame.maxY - panelSize.height - verticalPadding
-            )
-        }
-
-        return CGPoint(x: x, y: chosenY)
-    }
-
-    private func approximatelyEqual(_ lhs: CGRect, _ rhs: CGRect, tolerance: CGFloat = 0.5) -> Bool {
-        abs(lhs.origin.x - rhs.origin.x) <= tolerance
-            && abs(lhs.origin.y - rhs.origin.y) <= tolerance
-            && abs(lhs.size.width - rhs.size.width) <= tolerance
-            && abs(lhs.size.height - rhs.size.height) <= tolerance
     }
 }
 
-private final class SlashCommandPanel: NSPanel {
+private final class SlashCommandPanel: ContextualSurfacePanel {
     private let onKeyboardAction: (SlashCommandKeyboardAction) -> Void
     private let onPassthroughKeyDown: (NSEvent) -> Void
 
@@ -191,14 +93,6 @@ private final class SlashCommandPanel: NSPanel {
         self.onKeyboardAction = onKeyboardAction
         self.onPassthroughKeyDown = onPassthroughKeyDown
         super.init(contentRect: contentRect, styleMask: style, backing: bufferingType, defer: flag)
-    }
-
-    override var canBecomeKey: Bool {
-        true
-    }
-
-    override var canBecomeMain: Bool {
-        false
     }
 
     override func keyDown(with event: NSEvent) {

--- a/Sources/NotesBridge/Views/SettingsView.swift
+++ b/Sources/NotesBridge/Views/SettingsView.swift
@@ -79,8 +79,8 @@ struct SettingsView: View {
                     }
 
                     LabeledContent(appModel.t("Accessibility")) {
-                        Text(appModel.interactionAvailability.accessibilityGranted ? appModel.t("Granted") : appModel.t("Required"))
-                            .foregroundStyle(appModel.interactionAvailability.accessibilityGranted ? .green : .orange)
+                        Text(appModel.interactionState.availability.accessibilityGranted ? appModel.t("Granted") : appModel.t("Required"))
+                            .foregroundStyle(appModel.interactionState.availability.accessibilityGranted ? .green : .orange)
                     }
 
                     HStack {
@@ -109,7 +109,7 @@ struct SettingsView: View {
                     Text(appModel.inlineEnhancementsSummary)
                         .foregroundStyle(.secondary)
 
-                    if appModel.isRunningBundledApp && !appModel.interactionAvailability.accessibilityGranted {
+                    if appModel.isRunningBundledApp && !appModel.interactionState.availability.accessibilityGranted {
                         Text(appModel.t("If NotesBridge is already checked in Accessibility but still shows Required here, remove it and add the current NotesBridge.app bundle again."))
                             .foregroundStyle(.secondary)
                     }

--- a/Tests/NotesBridgeTests/ContextualSurfacePositioningTests.swift
+++ b/Tests/NotesBridgeTests/ContextualSurfacePositioningTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+import SwiftUI
+@testable import NotesBridge
+
+@MainActor
+final class ContextualSurfacePositioningTests: XCTestCase {
+    private var controller: ContextualSurfaceController!
+
+    override func setUp() {
+        super.setUp()
+        controller = ContextualSurfaceController()
+    }
+
+    func testBestPanelOriginPreferredBelow() {
+        let anchorRect = CGRect(x: 100, y: 500, width: 200, height: 20)
+        let panelSize = CGSize(width: 260, height: 100)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+        // Preferred below (.minY)
+        let origin = controller.bestPanelOrigin(
+            for: anchorRect,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            preferredEdge: .minY
+        )
+
+        // anchorRect.minY - panelSize.height - verticalPadding (6)
+        // 500 - 100 - 6 = 394
+        XCTAssertEqual(origin.y, 394)
+        // unclampedX = 100 - 6 = 94
+        XCTAssertEqual(origin.x, 94)
+    }
+
+    func testBestPanelOriginPreferredAbove() {
+        let anchorRect = CGRect(x: 100, y: 500, width: 200, height: 20)
+        let panelSize = CGSize(width: 260, height: 100)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+        // Preferred above (.maxY)
+        let origin = controller.bestPanelOrigin(
+            for: anchorRect,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            preferredEdge: .maxY
+        )
+
+        // anchorRect.maxY + verticalPadding (10)
+        // 520 + 10 = 530
+        XCTAssertEqual(origin.y, 530)
+        // unclampedX = 100 + 100 - 130 = 70 (midX - panelSize.width / 2)
+        XCTAssertEqual(origin.x, 70)
+    }
+
+    func testBestPanelOriginFlipsBelowToAbove() {
+        // Anchor near bottom
+        let anchorRect = CGRect(x: 100, y: 50, width: 200, height: 20)
+        let panelSize = CGSize(width: 260, height: 100)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+        // Preferred below, but not enough space
+        let origin = controller.bestPanelOrigin(
+            for: anchorRect,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            preferredEdge: .minY
+        )
+
+        // Should flip to above: 70 + 6 = 76
+        XCTAssertEqual(origin.y, 76)
+    }
+
+    func testBestPanelOriginFlipsAboveToBelow() {
+        // Anchor near top
+        let anchorRect = CGRect(x: 100, y: 950, width: 200, height: 20)
+        let panelSize = CGSize(width: 260, height: 100)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+        // Preferred above, but not enough space
+        let origin = controller.bestPanelOrigin(
+            for: anchorRect,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            preferredEdge: .maxY
+        )
+
+        // Should flip to below: 950 - 100 - 10 = 840
+        XCTAssertEqual(origin.y, 840)
+    }
+
+    func testBestPanelOriginClampsToEdges() {
+        let anchorRect = CGRect(x: 950, y: 500, width: 20, height: 20)
+        let panelSize = CGSize(width: 260, height: 100)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+        let origin = controller.bestPanelOrigin(
+            for: anchorRect,
+            panelSize: panelSize,
+            visibleFrame: visibleFrame,
+            preferredEdge: .minY
+        )
+
+        // x should be clamped to visibleFrame.maxX - panelSize.width - 8
+        // 1000 - 260 - 8 = 732
+        XCTAssertEqual(origin.x, 732)
+    }
+}


### PR DESCRIPTION
Resolves #10

This PR unifies the interaction model for the contextual command surfaces:
- Merged the positioning, bounding, and flipping logic into a shared `ContextualSurfaceController` foundation.
- Fixed the flickering root cause by ensuring non-interactive panels like the Formatting Bar do not steal Key Window focus (`becomesKeyOnlyIfNeeded` and `orderFrontRegardless`).
- Improved accessibility selection reading resilience by implementing a 'sticky focus' logic in `NotesContextMonitor` so that valid interactions don't reset the editing context.
- Added positioning and alignment unit tests.