### PR TITLE
Prepare 0.2.7 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable user-visible changes to NotesBridge should be documented here.
 
 This file is the source of truth for GitHub Release notes and Sparkle update notes.
 
+## [0.2.7] - 2026-03-25
+
+### Added
+
+- Added a localized product website in English, Simplified Chinese, and French.
+
+### Changed
+
+- Unified the slash menu and inline formatting surfaces so contextual editing popups share more stable positioning, bounds handling, and interaction behavior.
+- Switched the NotesBridge website and Sparkle update feed to `notesbridge.peizh.live`.
+
+### Fixed
+
+- Fixed floating formatting bar flicker caused by the contextual panel stealing key-window focus while editing.
+- Fixed localized landing-page brand links so translated site variants keep users on the current language page.
+
+### Distribution
+
+- Direct-download build.
+- Ad-hoc signed.
+- Not notarized yet.
+
 ## [0.2.6] - 2026-03-24
 
 ### Added


### PR DESCRIPTION
## Summary
- add the `0.2.7` changelog entry
- keep GitHub release notes and Sparkle update notes aligned with the repository source of truth

## Validation
- `./scripts/notesbridge.sh release-notes 0.2.7`

## Notes
- no app rebuild/relaunch was performed because this PR only updates release notes