### PR TITLE
Fix local test framework path resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,21 @@
 // swift-tools-version: 6.2
 import PackageDescription
+import Foundation
+
+private func resolvedTestingFrameworksPath() -> String {
+    let fileManager = FileManager.default
+    let candidates = [
+        ProcessInfo.processInfo.environment["DEVELOPER_DIR"]
+            .map { "\($0)/Platforms/MacOSX.platform/Developer/Library/Frameworks" },
+        "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+        "/Library/Developer/CommandLineTools/Library/Developer/Frameworks",
+    ].compactMap { $0 }
+
+    return candidates.first(where: { fileManager.fileExists(atPath: "\($0)/Testing.framework") })
+        ?? "/Library/Developer/CommandLineTools/Library/Developer/Frameworks"
+}
+
+let testingFrameworksDirectory = resolvedTestingFrameworksPath()
 
 let package = Package(
     name: "NotesBridge",
@@ -29,17 +45,17 @@ let package = Package(
             dependencies: ["NotesBridge"],
             swiftSettings: [
                 .unsafeFlags([
-                    "-F/Library/Developer/CommandLineTools/Library/Developer/Frameworks",
-                    "-I/Library/Developer/CommandLineTools/Library/Developer/Frameworks",
+                    "-F\(testingFrameworksDirectory)",
+                    "-I\(testingFrameworksDirectory)",
                 ]),
             ],
             linkerSettings: [
                 .unsafeFlags([
-                    "-F/Library/Developer/CommandLineTools/Library/Developer/Frameworks",
+                    "-F\(testingFrameworksDirectory)",
                     "-Xlinker",
                     "-rpath",
                     "-Xlinker",
-                    "/Library/Developer/CommandLineTools/Library/Developer/Frameworks",
+                    testingFrameworksDirectory,
                 ]),
             ]
         ),


### PR DESCRIPTION
## Summary
- stop hardcoding the Command Line Tools Testing.framework path for the test target
- resolve the Testing.framework path from the selected Xcode first, then fall back to CLT
- restore local `swift test` and `xcodebuild test` compatibility when Xcode and CLT versions diverge

## Validation
- `swift test`
- `xcodebuild -scheme NotesBridge -workspace .swiftpm/xcode/package.xcworkspace -destination 'platform=macOS' test`
- `./scripts/notesbridge.sh dev`

## Notes
- leaves existing local edits in AppleNotesNoteProtoDecoder files out of this PR
