### PR TITLE
Fix checklist-to-link markdown separation and streamline CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "agent/**"
   pull_request:
 
 jobs:
@@ -82,9 +81,6 @@ jobs:
 
       - name: Resolve package dependencies
         run: swift package resolve
-
-      - name: Run Swift tests
-        run: swift test
 
       - name: Run Xcode tests
         run: xcodebuild -scheme NotesBridge -workspace .swiftpm/xcode/package.xcworkspace -destination 'platform=macOS' test

--- a/Sources/NotesBridge/Services/AppleNotesNoteProtoDecoder.swift
+++ b/Sources/NotesBridge/Services/AppleNotesNoteProtoDecoder.swift
@@ -450,6 +450,7 @@ private extension AppleNotesMarkdownRenderer {
         var listNumber = 0
         var listIndent = 0
         var insideMonospacedBlock = false
+        var lastRenderedParagraphStyle: AppleNotesDecodedParagraphStyle?
 
         var finalizedMarkdown: String {
             let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -486,10 +487,12 @@ private extension AppleNotesMarkdownRenderer {
                 if insideMonospacedBlock {
                     output.append(segment)
                     isAtLineStart = false
+                    lastRenderedParagraphStyle = run.paragraphStyle
                     continue
                 }
 
                 if isAtLineStart {
+                    ensureParagraphSeparation(before: run)
                     output.append(paragraphPrefix(for: run))
                 }
 
@@ -503,6 +506,7 @@ private extension AppleNotesMarkdownRenderer {
                     output.append(formattedText(segment, run: run))
                 }
                 isAtLineStart = false
+                lastRenderedParagraphStyle = run.paragraphStyle
             }
         }
 
@@ -524,18 +528,24 @@ private extension AppleNotesMarkdownRenderer {
             switch try attachmentResolver(attachmentInfo) {
             case let .inlineText(text):
                 if isAtLineStart && !insideMonospacedBlock {
+                    ensureParagraphSeparation(before: run)
                     output.append(paragraphPrefix(for: run))
                 }
                 output.append(text)
                 isAtLineStart = text.hasSuffix("\n")
+                if !text.isEmpty {
+                    lastRenderedParagraphStyle = run.paragraphStyle
+                }
 
             case let .internalLink(link):
                 if isAtLineStart && !insideMonospacedBlock {
+                    ensureParagraphSeparation(before: run)
                     output.append(paragraphPrefix(for: run))
                 }
                 let placeholder = appendInternalLink(link)
                 output.append(placeholder)
                 isAtLineStart = false
+                lastRenderedParagraphStyle = run.paragraphStyle
 
             case let .attachment(attachment, isBlock):
                 let fragment = AppleNotesRenderedFragment(
@@ -569,6 +579,7 @@ private extension AppleNotesMarkdownRenderer {
                     output.append("\n")
                 }
                 if isAtLineStart && !insideMonospacedBlock {
+                    ensureParagraphSeparation(before: run)
                     output.append(paragraphPrefix(for: run))
                 }
                 output.append(uniqued.markdownTemplate)
@@ -576,14 +587,17 @@ private extension AppleNotesMarkdownRenderer {
                     output.append("\n")
                 }
                 isAtLineStart = true
+                lastRenderedParagraphStyle = run.paragraphStyle
                 return
             }
 
             if isAtLineStart && !insideMonospacedBlock {
+                ensureParagraphSeparation(before: run)
                 output.append(paragraphPrefix(for: run))
             }
             output.append(uniqued.markdownTemplate)
             isAtLineStart = uniqued.markdownTemplate.hasSuffix("\n")
+            lastRenderedParagraphStyle = run.paragraphStyle
         }
 
         private mutating func uniquedFragment(_ fragment: AppleNotesRenderedFragment) -> AppleNotesRenderedFragment {
@@ -682,6 +696,21 @@ private extension AppleNotesMarkdownRenderer {
             isAtLineStart = true
         }
 
+        private mutating func ensureParagraphSeparation(before run: AppleNotesDecodedAttributeRun) {
+            guard !output.isEmpty, isAtLineStart, !output.hasSuffix("\n\n") else {
+                return
+            }
+
+            let previousStyleType = lastRenderedParagraphStyle?.styleType ?? AppleNotesStyleType.default.rawValue
+            let currentStyleType = run.paragraphStyle?.styleType ?? AppleNotesStyleType.default.rawValue
+
+            guard isListStyle(previousStyleType), !isListStyle(currentStyleType) else {
+                return
+            }
+
+            output.append("\n")
+        }
+
         private mutating func paragraphPrefix(for run: AppleNotesDecodedAttributeRun) -> String {
             let paragraphStyle = run.paragraphStyle
             let styleType = paragraphStyle?.styleType ?? AppleNotesStyleType.default.rawValue
@@ -713,6 +742,18 @@ private extension AppleNotesMarkdownRenderer {
                 return prelude + indent + "- \(checked) "
             default:
                 return prelude
+            }
+        }
+
+        private func isListStyle(_ styleType: Int) -> Bool {
+            switch styleType {
+            case AppleNotesStyleType.dottedList.rawValue,
+                 AppleNotesStyleType.dashedList.rawValue,
+                 AppleNotesStyleType.numberedList.rawValue,
+                 AppleNotesStyleType.checkbox.rawValue:
+                return true
+            default:
+                return false
             }
         }
 

--- a/Tests/NotesBridgeTests/AppleNotesMarkdownRendererTests.swift
+++ b/Tests/NotesBridgeTests/AppleNotesMarkdownRendererTests.swift
@@ -325,6 +325,22 @@ struct AppleNotesMarkdownRendererTests {
     }
 
     @Test
+    func insertsBlankLineBetweenChecklistAndFollowingLinkParagraph() throws {
+        let note = makeNote(
+            segments: [
+                segment("Confirm source\n", styleType: 103),
+                segment("Open reference", link: "https://example.com"),
+            ]
+        )
+
+        let rendered = try renderer.render(note: note) { _ in
+            .inlineText("")
+        }
+
+        #expect(rendered.markdownTemplate == "- [ ] Confirm source\n\n[Open reference](https://example.com)")
+    }
+
+    @Test
     func collectsInternalLinksReturnedFromAttachmentResolver() throws {
         let note = makeNote(
             segments: [


### PR DESCRIPTION
## Summary

- add paragraph separation when Markdown rendering transitions from checklist/list content to a following non-list paragraph or link
- add a regression test for checklist-to-link output so Markdown preview keeps rendering the link block correctly
- remove the redundant `swift test` CI step and stop running push workflows for `agent/**` branches to avoid duplicate CI runs

## Linked issue

- None

## Validation

- [x] `swift test`
- [x] `xcodebuild -scheme NotesBridge -workspace .swiftpm/xcode/package.xcworkspace -destination 'platform=macOS' test`
- [x] Manual validation completed when needed (`./scripts/notesbridge.sh dev`)

## Risks / regressions checked

- [x] Sync / import behavior
- [x] Obsidian export paths or attachments
- [x] Apple Notes conversion output
- [x] Slash commands / inline tools
- [x] Permissions / launch flow

## Notes for reviewers

- CI workflow cleanup is bundled with the renderer fix because both changes are already part of the same local commit.
