### PR TITLE
Reduce redundant full-vault work during incremental sync

### DIFF
--- a/Sources/NotesBridge/App/AppModel.swift
+++ b/Sources/NotesBridge/App/AppModel.swift
@@ -129,6 +129,7 @@ final class AppModel: ObservableObject {
     private let formattingBarController: FloatingFormattingBarController
     private let statusObserver: (@MainActor @Sendable (String) -> Void)?
     private let appleNotesDataFolderAccessSessionFactory: AppleNotesDataFolderAccessSessionFactory
+    private let automaticSyncDebounceInterval: TimeInterval
     private var syncIndex: SyncIndex
     private var syncAnimationCancellable: AnyCancellable?
     private var automaticSyncCancellable: AnyCancellable?
@@ -152,6 +153,7 @@ final class AppModel: ObservableObject {
         statusObserver: (@MainActor @Sendable (String) -> Void)? = nil,
         appleNotesDataFolderAccessSessionFactory: @escaping AppleNotesDataFolderAccessSessionFactory = makeAppleNotesDataFolderAccessSession,
         notesDatabaseWatcher: any NotesDatabaseWatching = NotesDatabaseWatcher(),
+        automaticSyncDebounceInterval: TimeInterval = 5.0,
         startImmediately: Bool = true
     ) {
         let resolvedBuildFlavor = buildFlavor
@@ -197,6 +199,7 @@ final class AppModel: ObservableObject {
         self.formattingBarController = formattingBarController
         self.statusObserver = statusObserver
         self.appleNotesDataFolderAccessSessionFactory = appleNotesDataFolderAccessSessionFactory
+        self.automaticSyncDebounceInterval = automaticSyncDebounceInterval
         self.interactionState = InteractionState(
             selectionContext: nil,
             availability: .default(for: resolvedBuildFlavor)
@@ -1489,9 +1492,9 @@ final class AppModel: ObservableObject {
 
     private func handleDatabaseChange() {
         pendingOnChangeSyncTask?.cancel()
+        let debounceIntervalNanoseconds = UInt64(max(automaticSyncDebounceInterval, 0) * 1_000_000_000)
         pendingOnChangeSyncTask = Task {
-            // Debounce 5 seconds
-            try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: debounceIntervalNanoseconds)
             if Task.isCancelled { return }
             await runAutomaticSyncIfNeeded()
         }

--- a/Sources/NotesBridge/App/AppModel.swift
+++ b/Sources/NotesBridge/App/AppModel.swift
@@ -132,7 +132,7 @@ final class AppModel: ObservableObject {
     private var syncIndex: SyncIndex
     private var syncAnimationCancellable: AnyCancellable?
     private var automaticSyncCancellable: AnyCancellable?
-    private let notesDatabaseWatcher: NotesDatabaseWatcher
+    private let notesDatabaseWatcher: any NotesDatabaseWatching
     private var watcherAccessSession: AppleNotesDataFolderAccessSession?
     private var pendingOnChangeSyncTask: Task<Void, Never>?
     private var cancellables: Set<AnyCancellable> = []
@@ -151,9 +151,11 @@ final class AppModel: ObservableObject {
         permissionsManager: PermissionsManager = PermissionsManager(),
         statusObserver: (@MainActor @Sendable (String) -> Void)? = nil,
         appleNotesDataFolderAccessSessionFactory: @escaping AppleNotesDataFolderAccessSessionFactory = makeAppleNotesDataFolderAccessSession,
+        notesDatabaseWatcher: any NotesDatabaseWatching = NotesDatabaseWatcher(),
         startImmediately: Bool = true
     ) {
         let resolvedBuildFlavor = buildFlavor
+        let resolvedNotesDatabaseWatcher = notesDatabaseWatcher
         self.notesClient = notesClient
         self.appleNotesSyncDataSource = appleNotesSyncDataSource
         self.appleNotesDataFolderSelector = appleNotesDataFolderSelector
@@ -199,8 +201,8 @@ final class AppModel: ObservableObject {
             selectionContext: nil,
             availability: .default(for: resolvedBuildFlavor)
         )
-        self.notesDatabaseWatcher = NotesDatabaseWatcher()
-        self.notesDatabaseWatcher.onChange = { [weak self] in
+        self.notesDatabaseWatcher = resolvedNotesDatabaseWatcher
+        resolvedNotesDatabaseWatcher.onChange = { [weak self] in
             self?.handleDatabaseChange()
         }
         self.slashCommandEngine.onKeyboardNavigationAvailabilityChanged = { [weak self] isAvailable in
@@ -724,6 +726,7 @@ final class AppModel: ObservableObject {
                     let scanExistingStart = Date()
                     indexedRelativePaths = try vaultClient.indexExistingNotes(settings: settings)
                     timings.scanExisting = Date().timeIntervalSince(scanExistingStart)
+                    timings.usedRecoveryScan = true
                     updatedSyncIndex.mergePathAliases(indexedRelativePaths)
                 } else {
                     indexedRelativePaths = [:]
@@ -736,27 +739,51 @@ final class AppModel: ObservableObject {
                     settings: settings
                 )
 
-                let noteIDsToLoad = Set(plan.exports.map(\.manifestEntry.databaseNoteID))
-                let loadDocumentsStart = Date()
-                let changedSnapshot = try {
-                    if let accessSession = accessSessionFactory(dataFolderSelection.rootURL.path, dataFolderBookmark) {
-                        defer { accessSession.stopAccessing() }
+                if plan.exports.isEmpty && plan.removedRecords.isEmpty {
+                    timings.total = Date().timeIntervalSince(totalStart)
+                    return IncrementalSyncResult(
+                        folders: plan.folders,
+                        updatedRecords: syncIndexSnapshot.records,
+                        processedNoteCount: plan.processedNoteCount,
+                        addedNoteCount: 0,
+                        updatedNoteCount: 0,
+                        removedNoteCount: 0,
+                        unchangedNoteCount: plan.unchangedNoteCount,
+                        pathAliases: updatedSyncIndex.pathAliases,
+                        timings: timings,
+                        diagnostics: IncrementalSyncDiagnostics(
+                            skippedNotes: plan.skippedLockedNotes,
+                            unresolvedInternalLinks: 0
+                        )
+                    )
+                }
+
+                let changedDocumentsByID: [String: AppleNotesSyncDocument]
+                if plan.exports.isEmpty {
+                    changedDocumentsByID = [:]
+                } else {
+                    let noteIDsToLoad = Set(plan.exports.map(\.manifestEntry.databaseNoteID))
+                    let loadDocumentsStart = Date()
+                    let changedSnapshot = try {
+                        if let accessSession = accessSessionFactory(dataFolderSelection.rootURL.path, dataFolderBookmark) {
+                            defer { accessSession.stopAccessing() }
+                            return try appleNotesSyncDataSource.loadDocuments(
+                                fromDataFolder: accessSession.url.path,
+                                noteIDs: noteIDsToLoad,
+                                preferredDatabaseRelativePath: manifest.selectedDatabaseRelativePath
+                            )
+                        }
                         return try appleNotesSyncDataSource.loadDocuments(
-                            fromDataFolder: accessSession.url.path,
+                            fromDataFolder: dataFolderSelection.rootURL.path,
                             noteIDs: noteIDsToLoad,
                             preferredDatabaseRelativePath: manifest.selectedDatabaseRelativePath
                         )
-                    }
-                    return try appleNotesSyncDataSource.loadDocuments(
-                        fromDataFolder: dataFolderSelection.rootURL.path,
-                        noteIDs: noteIDsToLoad,
-                        preferredDatabaseRelativePath: manifest.selectedDatabaseRelativePath
+                    }()
+                    timings.loadChangedDocuments = Date().timeIntervalSince(loadDocumentsStart)
+                    changedDocumentsByID = Dictionary(
+                        uniqueKeysWithValues: changedSnapshot.documents.map { ($0.id, $0) }
                     )
-                }()
-                timings.loadChangedDocuments = Date().timeIntervalSince(loadDocumentsStart)
-                let changedDocumentsByID = Dictionary(
-                    uniqueKeysWithValues: changedSnapshot.documents.map { ($0.id, $0) }
-                )
+                }
 
                 var missingDocumentIDs: [String] = []
                 for plannedExport in plan.exports where changedDocumentsByID[plannedExport.manifestEntry.id] == nil {
@@ -832,13 +859,17 @@ final class AppModel: ObservableObject {
 
                 let removeDeletedStart = Date()
                 var movedRemovedNotes = 0
+                var occupiedRemovalPaths = updatedSyncIndex.occupiedRelativePaths
                 for removedRecord in plan.removedRecords {
-                    if try vaultClient.moveExportedNoteToRemoved(
+                    if let removedRelativePath = try vaultClient.moveExportedNoteToRemoved(
                         relativePath: removedRecord.relativePath,
-                        settings: settings
-                    ) != nil {
+                        settings: settings,
+                        occupiedRelativePaths: occupiedRemovalPaths
+                    ) {
                         movedRemovedNotes += 1
+                        occupiedRemovalPaths.insert(removedRelativePath)
                     }
+                    occupiedRemovalPaths.remove(removedRecord.relativePath)
                     updatedSyncIndex.removePathAliases(forRelativePath: removedRecord.relativePath)
                     updatedSyncIndex.removePathAliases(for: [removedRecord.noteID])
                     updatedRecords.removeValue(forKey: removedRecord.noteID)
@@ -1175,6 +1206,7 @@ final class AppModel: ObservableObject {
                     let scanExistingStart = Date()
                     indexedRelativePaths = try vaultClient.indexExistingNotes(settings: settings)
                     timings.scanExisting = Date().timeIntervalSince(scanExistingStart)
+                    timings.usedRecoveryScan = true
                     updatedSyncIndex.mergePathAliases(indexedRelativePaths)
                     AppLog.sync.info("Indexed \(indexedRelativePaths.count) existing synced note path(s).")
                 } else {
@@ -1624,10 +1656,12 @@ private struct SyncTimings: Sendable {
     var scanExisting: TimeInterval = 0
     var export: TimeInterval = 0
     var total: TimeInterval = 0
+    var usedRecoveryScan = false
 
     func summary(persistIndex: TimeInterval) -> String {
         let totalDuration = total + persistIndex
-        return "Total \(totalDuration.formattedDuration); snapshot \(loadSnapshot.formattedDuration); index \(scanExisting.formattedDuration); export \(export.formattedDuration); persist \(persistIndex.formattedDuration)."
+        let indexMode = usedRecoveryScan ? "recovered" : "cached"
+        return "Total \(totalDuration.formattedDuration); snapshot \(loadSnapshot.formattedDuration); index \(scanExisting.formattedDuration) (\(indexMode)); export \(export.formattedDuration); persist \(persistIndex.formattedDuration)."
     }
 }
 
@@ -1638,10 +1672,12 @@ private struct IncrementalSyncTimings: Sendable {
     var removeDeleted: TimeInterval = 0
     var export: TimeInterval = 0
     var total: TimeInterval = 0
+    var usedRecoveryScan = false
 
     func summary(persistIndex: TimeInterval) -> String {
         let totalDuration = total + persistIndex
-        return "Total \(totalDuration.formattedDuration); manifest \(loadManifest.formattedDuration); changed \(loadChangedDocuments.formattedDuration); index \(scanExisting.formattedDuration); removed \(removeDeleted.formattedDuration); export \(export.formattedDuration); persist \(persistIndex.formattedDuration)."
+        let indexMode = usedRecoveryScan ? "recovered" : "cached"
+        return "Total \(totalDuration.formattedDuration); manifest \(loadManifest.formattedDuration); changed \(loadChangedDocuments.formattedDuration); index \(scanExisting.formattedDuration) (\(indexMode)); removed \(removeDeleted.formattedDuration); export \(export.formattedDuration); persist \(persistIndex.formattedDuration)."
     }
 }
 

--- a/Sources/NotesBridge/App/AppModel.swift
+++ b/Sources/NotesBridge/App/AppModel.swift
@@ -694,6 +694,21 @@ final class AppModel: ObservableObject {
             let result = try await Task.detached(priority: .utility) {
                 let totalStart = Date()
                 var timings = IncrementalSyncTimings()
+                var updatedSyncIndex = syncIndexSnapshot
+
+                func pathAliasIdentifiers(for document: AppleNotesSyncDocument) -> [String] {
+                    [
+                        document.id,
+                        document.sourceNoteIdentifierRaw,
+                        document.appleNotesDeepLink ?? "",
+                        document.legacyNoteID ?? "",
+                    ]
+                }
+
+                for record in updatedSyncIndex.records.values {
+                    updatedSyncIndex.rememberPath(record.relativePath, for: [record.noteID])
+                }
+
                 let loadManifestStart = Date()
                 let manifest = try {
                     if let accessSession = accessSessionFactory(dataFolderSelection.rootURL.path, dataFolderBookmark) {
@@ -704,13 +719,19 @@ final class AppModel: ObservableObject {
                 }()
                 timings.loadManifest = Date().timeIntervalSince(loadManifestStart)
 
-                let scanExistingStart = Date()
-                let indexedRelativePaths = try vaultClient.indexExistingNotes(settings: settings)
-                timings.scanExisting = Date().timeIntervalSince(scanExistingStart)
+                let indexedRelativePaths: [String: String]
+                if updatedSyncIndex.pathAliases.isEmpty {
+                    let scanExistingStart = Date()
+                    indexedRelativePaths = try vaultClient.indexExistingNotes(settings: settings)
+                    timings.scanExisting = Date().timeIntervalSince(scanExistingStart)
+                    updatedSyncIndex.mergePathAliases(indexedRelativePaths)
+                } else {
+                    indexedRelativePaths = [:]
+                }
 
                 let plan = incrementalSyncPlanner.plan(
                     manifest: manifest,
-                    syncIndex: syncIndexSnapshot,
+                    syncIndex: updatedSyncIndex,
                     indexedRelativePaths: indexedRelativePaths,
                     settings: settings
                 )
@@ -788,6 +809,10 @@ final class AppModel: ObservableObject {
                         )
                         timings.export += Date().timeIntervalSince(exportStart)
                         updatedRecords[syncResult.record.noteID] = syncResult.record
+                        updatedSyncIndex.rememberPath(
+                            syncResult.record.relativePath,
+                            for: pathAliasIdentifiers(for: document)
+                        )
                         switch syncResult.changeKind {
                         case .created:
                             addedNoteCount += 1
@@ -814,6 +839,8 @@ final class AppModel: ObservableObject {
                     ) != nil {
                         movedRemovedNotes += 1
                     }
+                    updatedSyncIndex.removePathAliases(forRelativePath: removedRecord.relativePath)
+                    updatedSyncIndex.removePathAliases(for: [removedRecord.noteID])
                     updatedRecords.removeValue(forKey: removedRecord.noteID)
                 }
                 timings.removeDeleted = Date().timeIntervalSince(removeDeletedStart)
@@ -827,6 +854,7 @@ final class AppModel: ObservableObject {
                     updatedNoteCount: updatedNoteCount,
                     removedNoteCount: movedRemovedNotes,
                     unchangedNoteCount: plan.unchangedNoteCount + exportedUnchangedNoteCount,
+                    pathAliases: updatedSyncIndex.pathAliases,
                     timings: timings,
                     diagnostics: IncrementalSyncDiagnostics(
                         skippedNotes: plan.skippedLockedNotes,
@@ -840,6 +868,7 @@ final class AppModel: ObservableObject {
             }
             syncIndex.knownFolderCount = folderSummaries.count
             syncIndex.records = result.updatedRecords
+            syncIndex.pathAliases = result.pathAliases
             let persistStart = Date()
             let now = Date()
             syncIndex.lastSyncAt = now
@@ -897,7 +926,7 @@ final class AppModel: ObservableObject {
         let settings = self.settings
         let dataFolderBookmark = self.settings.appleNotesDataBookmark
         let accessSessionFactory = self.appleNotesDataFolderAccessSessionFactory
-        let existingRecords = self.syncIndex.records
+        let syncIndexSnapshot = self.syncIndex
         let progressReporter = makeSyncProgressReporter()
 
         isSyncing = true
@@ -918,6 +947,20 @@ final class AppModel: ObservableObject {
                 let totalStart = Date()
                 var timings = SyncTimings()
                 var diagnostics = SyncDiagnostics()
+                var updatedSyncIndex = syncIndexSnapshot
+
+                func pathAliasIdentifiers(for document: AppleNotesSyncDocument) -> [String] {
+                    [
+                        document.id,
+                        document.sourceNoteIdentifierRaw,
+                        document.appleNotesDeepLink ?? "",
+                        document.legacyNoteID ?? "",
+                    ]
+                }
+
+                for record in updatedSyncIndex.records.values {
+                    updatedSyncIndex.rememberPath(record.relativePath, for: [record.noteID])
+                }
 
                 func sortedDocuments(_ documents: [AppleNotesSyncDocument]) -> [AppleNotesSyncDocument] {
                     documents.sorted {
@@ -937,7 +980,9 @@ final class AppModel: ObservableObject {
                     for noteID: String,
                     indexedRelativePaths: [String: String]
                 ) -> String? {
-                    existingRecords[noteID]?.relativePath ?? indexedRelativePaths[noteID]
+                    syncIndexSnapshot.records[noteID]?.relativePath
+                        ?? updatedSyncIndex.pathAliases[noteID]
+                        ?? indexedRelativePaths[noteID]
                 }
 
                 func legacyIdentifier(
@@ -945,10 +990,24 @@ final class AppModel: ObservableObject {
                     indexedRelativePaths: [String: String]
                 ) -> String? {
                     let legacySuffix = "/ICNote/p\(databaseNoteID)"
-                    if let syncIndexMatch = existingRecords.keys.first(where: { $0.hasSuffix(legacySuffix) }) {
+                    if let syncIndexMatch = syncIndexSnapshot.records.keys.first(where: { $0.hasSuffix(legacySuffix) }) {
                         return syncIndexMatch
                     }
-                    return indexedRelativePaths.keys.first(where: { $0.hasSuffix(legacySuffix) })
+                    if let aliasMatch = updatedSyncIndex.pathAliases.keys.first(where: { $0.hasSuffix(legacySuffix) }) {
+                        return aliasMatch
+                    }
+                    if let recoveredMatch = indexedRelativePaths.keys.first(where: { $0.hasSuffix(legacySuffix) }) {
+                        return recoveredMatch
+                    }
+                    return nil
+                }
+
+                func buildOccupiedRelativePaths(
+                    indexedRelativePaths: [String: String]
+                ) -> Set<String> {
+                    var occupiedRelativePaths = updatedSyncIndex.occupiedRelativePaths
+                    occupiedRelativePaths.formUnion(indexedRelativePaths.values)
+                    return occupiedRelativePaths
                 }
 
                 func buildExportGroups(
@@ -1023,7 +1082,7 @@ final class AppModel: ObservableObject {
                     groups: [FolderExportGroup],
                     indexedRelativePaths: [String: String]
                 ) -> ([PlannedFolderExportGroup], [String: String], Set<String>) {
-                    var occupiedRelativePaths = Set(indexedRelativePaths.values)
+                    var occupiedRelativePaths = buildOccupiedRelativePaths(indexedRelativePaths: indexedRelativePaths)
                     var plannedRelativePathsBySourceIdentifier: [String: String] = [:]
                     var migratedLegacyIDs: Set<String> = []
                     var plannedGroups: [PlannedFolderExportGroup] = []
@@ -1111,10 +1170,16 @@ final class AppModel: ObservableObject {
                     )
                 }
 
-                let scanExistingStart = Date()
-                let indexedRelativePaths = try vaultClient.indexExistingNotes(settings: settings)
-                timings.scanExisting = Date().timeIntervalSince(scanExistingStart)
-                AppLog.sync.info("Indexed \(indexedRelativePaths.count) existing synced note path(s).")
+                let indexedRelativePaths: [String: String]
+                if updatedSyncIndex.pathAliases.isEmpty {
+                    let scanExistingStart = Date()
+                    indexedRelativePaths = try vaultClient.indexExistingNotes(settings: settings)
+                    timings.scanExisting = Date().timeIntervalSince(scanExistingStart)
+                    updatedSyncIndex.mergePathAliases(indexedRelativePaths)
+                    AppLog.sync.info("Indexed \(indexedRelativePaths.count) existing synced note path(s).")
+                } else {
+                    indexedRelativePaths = [:]
+                }
 
                 let folders = snapshot.folders.sorted {
                     $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
@@ -1169,6 +1234,10 @@ final class AppModel: ObservableObject {
                         )
                         timings.export += Date().timeIntervalSince(exportStart)
                         records.append(syncResult.record)
+                        updatedSyncIndex.rememberPath(
+                            syncResult.record.relativePath,
+                            for: pathAliasIdentifiers(for: plannedDocument.document)
+                        )
                         switch syncResult.changeKind {
                         case .created:
                             addedNoteCount += 1
@@ -1217,6 +1286,7 @@ final class AppModel: ObservableObject {
                     updatedNoteCount: updatedNoteCount,
                     unchangedNoteCount: unchangedNoteCount,
                     records: records,
+                    pathAliases: updatedSyncIndex.pathAliases,
                     timings: timings,
                     diagnostics: diagnostics,
                     migratedLegacyIDs: migratedLegacyIDs
@@ -1232,6 +1302,7 @@ final class AppModel: ObservableObject {
             for record in result.records {
                 syncIndex.records[record.noteID] = record
             }
+            syncIndex.pathAliases = result.pathAliases
             let persistStart = Date()
             let now = Date()
             syncIndex.knownFolderCount = result.folders.count
@@ -1455,6 +1526,7 @@ private struct FullSyncResult {
     var updatedNoteCount: Int
     var unchangedNoteCount: Int
     var records: [SyncRecord]
+    var pathAliases: [String: String]
     var timings: SyncTimings
     var diagnostics: SyncDiagnostics
     var migratedLegacyIDs: Set<String>
@@ -1468,6 +1540,7 @@ private struct IncrementalSyncResult {
     var updatedNoteCount: Int
     var removedNoteCount: Int
     var unchangedNoteCount: Int
+    var pathAliases: [String: String]
     var timings: IncrementalSyncTimings
     var diagnostics: IncrementalSyncDiagnostics
 }

--- a/Sources/NotesBridge/Domain/SyncRecord.swift
+++ b/Sources/NotesBridge/Domain/SyncRecord.swift
@@ -35,6 +35,7 @@ enum SyncRunMode: String, Codable, Sendable {
 
 struct SyncIndex: Codable, Sendable {
     var records: [String: SyncRecord] = [:]
+    var pathAliases: [String: String] = [:]
     var knownFolderCount: Int?
     var lastSyncAt: Date?
     var lastSyncMode: SyncRunMode?
@@ -43,4 +44,54 @@ struct SyncIndex: Codable, Sendable {
     var lastFullSyncAt: Date?
     var lastFullSyncNoteCount: Int?
     var lastFullSyncFolderCount: Int?
+
+    mutating func rememberPath(_ relativePath: String, for identifiers: [String]) {
+        for identifier in identifiers where !identifier.isEmpty {
+            pathAliases[identifier] = relativePath
+        }
+    }
+
+    mutating func removePathAliases(for identifiers: [String]) {
+        for identifier in identifiers where !identifier.isEmpty {
+            pathAliases.removeValue(forKey: identifier)
+        }
+    }
+
+    init(
+        records: [String: SyncRecord] = [:],
+        pathAliases: [String: String] = [:],
+        knownFolderCount: Int? = nil,
+        lastSyncAt: Date? = nil,
+        lastSyncMode: SyncRunMode? = nil,
+        lastIncrementalSyncAt: Date? = nil,
+        lastAutomaticSyncAt: Date? = nil,
+        lastFullSyncAt: Date? = nil,
+        lastFullSyncNoteCount: Int? = nil,
+        lastFullSyncFolderCount: Int? = nil
+    ) {
+        self.records = records
+        self.pathAliases = pathAliases
+        self.knownFolderCount = knownFolderCount
+        self.lastSyncAt = lastSyncAt
+        self.lastSyncMode = lastSyncMode
+        self.lastIncrementalSyncAt = lastIncrementalSyncAt
+        self.lastAutomaticSyncAt = lastAutomaticSyncAt
+        self.lastFullSyncAt = lastFullSyncAt
+        self.lastFullSyncNoteCount = lastFullSyncNoteCount
+        self.lastFullSyncFolderCount = lastFullSyncFolderCount
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.records = try container.decodeIfPresent([String: SyncRecord].self, forKey: .records) ?? [:]
+        self.pathAliases = try container.decodeIfPresent([String: String].self, forKey: .pathAliases) ?? [:]
+        self.knownFolderCount = try container.decodeIfPresent(Int.self, forKey: .knownFolderCount)
+        self.lastSyncAt = try container.decodeIfPresent(Date.self, forKey: .lastSyncAt)
+        self.lastSyncMode = try container.decodeIfPresent(SyncRunMode.self, forKey: .lastSyncMode)
+        self.lastIncrementalSyncAt = try container.decodeIfPresent(Date.self, forKey: .lastIncrementalSyncAt)
+        self.lastAutomaticSyncAt = try container.decodeIfPresent(Date.self, forKey: .lastAutomaticSyncAt)
+        self.lastFullSyncAt = try container.decodeIfPresent(Date.self, forKey: .lastFullSyncAt)
+        self.lastFullSyncNoteCount = try container.decodeIfPresent(Int.self, forKey: .lastFullSyncNoteCount)
+        self.lastFullSyncFolderCount = try container.decodeIfPresent(Int.self, forKey: .lastFullSyncFolderCount)
+    }
 }

--- a/Sources/NotesBridge/Domain/SyncRecord.swift
+++ b/Sources/NotesBridge/Domain/SyncRecord.swift
@@ -57,6 +57,23 @@ struct SyncIndex: Codable, Sendable {
         }
     }
 
+    mutating func removePathAliases(forRelativePath relativePath: String) {
+        let identifiers = pathAliases.compactMap { identifier, candidateRelativePath in
+            candidateRelativePath == relativePath ? identifier : nil
+        }
+        removePathAliases(for: identifiers)
+    }
+
+    mutating func mergePathAliases(_ aliases: [String: String]) {
+        for (identifier, relativePath) in aliases where !identifier.isEmpty {
+            pathAliases[identifier] = relativePath
+        }
+    }
+
+    var occupiedRelativePaths: Set<String> {
+        Set(records.values.map(\.relativePath)).union(pathAliases.values)
+    }
+
     init(
         records: [String: SyncRecord] = [:],
         pathAliases: [String: String] = [:],

--- a/Sources/NotesBridge/Services/IncrementalSyncPlanner.swift
+++ b/Sources/NotesBridge/Services/IncrementalSyncPlanner.swift
@@ -36,7 +36,8 @@ struct IncrementalSyncPlanner: Sendable {
         let trashedEntryIDs = Set(manifest.entries.filter(\.trashed).map(\.id))
         let presentEntryIDs = Set(manifest.entries.map(\.id))
 
-        var occupiedRelativePaths = Set(indexedRelativePaths.values)
+        var occupiedRelativePaths = syncIndex.occupiedRelativePaths
+        occupiedRelativePaths.formUnion(indexedRelativePaths.values)
         var plannedRelativePathsBySourceIdentifier: [String: String] = [:]
         var exports: [PlannedIncrementalDocumentExport] = []
         var unchangedNoteCount = 0
@@ -125,6 +126,20 @@ struct IncrementalSyncPlanner: Sendable {
         indexedRelativePaths: [String: String]
     ) -> String? {
         if let relativePath = syncIndex.records[entry.id]?.relativePath {
+            return relativePath
+        }
+
+        if let relativePath = syncIndex.pathAliases[entry.id] {
+            return relativePath
+        }
+
+        if let relativePath = syncIndex.pathAliases[entry.sourceNoteIdentifierRaw] {
+            return relativePath
+        }
+
+        if let deepLink = entry.appleNotesDeepLink,
+           let relativePath = syncIndex.pathAliases[deepLink]
+        {
             return relativePath
         }
 

--- a/Sources/NotesBridge/Services/NotesDatabaseWatcher.swift
+++ b/Sources/NotesBridge/Services/NotesDatabaseWatcher.swift
@@ -1,44 +1,68 @@
+import Dispatch
 import Foundation
-import OSLog
 
-@MainActor
-final class NotesDatabaseWatcher {
+protocol NotesDatabaseWatching: AnyObject {
+    var onChange: (@MainActor @Sendable () -> Void)? { get set }
+    func start(dataFolderURL: URL)
+    func stop()
+}
+
+final class NotesDatabaseWatcher: NotesDatabaseWatching, @unchecked Sendable {
     var onChange: (@MainActor @Sendable () -> Void)?
-    private let pollInterval: TimeInterval = 2.0
+
+    private let pollInterval: TimeInterval
+    private let queue: DispatchQueue
     private var isRunning = false
     private var hasEstablishedBaseline = false
     private var lastModificationDates: [URL: Date] = [:]
-    private var timer: Timer?
+    private var timer: DispatchSourceTimer?
     private var dataFolderURL: URL?
 
-    init() {}
+    init(
+        pollInterval: TimeInterval = 2.0,
+        queue: DispatchQueue = DispatchQueue(label: "dev.notesbridge.watcher")
+    ) {
+        self.pollInterval = pollInterval
+        self.queue = queue
+    }
 
     func start(dataFolderURL: URL) {
-        self.dataFolderURL = dataFolderURL
-        self.isRunning = true
-        self.hasEstablishedBaseline = false
-        self.lastModificationDates = [:]
+        stop()
 
-        self.scheduleTimer()
-    }
+        queue.sync {
+            self.dataFolderURL = dataFolderURL
+            self.isRunning = true
+            self.hasEstablishedBaseline = false
+            self.lastModificationDates = [:]
 
-    func stop() {
-        isRunning = false
-        self.timer?.invalidate()
-        self.timer = nil
-    }
-
-    private func scheduleTimer() {
-        timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor in
+            let timer = DispatchSource.makeTimerSource(queue: queue)
+            timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
+            timer.setEventHandler { [weak self] in
                 self?.check()
             }
+            self.timer = timer
+            timer.resume()
         }
     }
 
+    func stop() {
+        let timer = queue.sync { () -> DispatchSourceTimer? in
+            isRunning = false
+            dataFolderURL = nil
+            hasEstablishedBaseline = false
+            lastModificationDates = [:]
+
+            let timer = self.timer
+            self.timer = nil
+            return timer
+        }
+
+        timer?.setEventHandler {}
+        timer?.cancel()
+    }
+
     private func check() {
-        guard isRunning, let dataFolderURL = dataFolderURL else { return }
+        guard isRunning, let dataFolderURL else { return }
 
         let databaseURLs = findDatabaseFiles(in: dataFolderURL)
         var changed = false
@@ -55,13 +79,19 @@ final class NotesDatabaseWatcher {
                     lastModificationDates[url] = modificationDate
                 }
             } catch {
-                // File might be temporarily missing or unreadable
+                // File might be temporarily missing or unreadable.
             }
         }
 
         hasEstablishedBaseline = true
 
         if changed {
+            emitChange()
+        }
+    }
+
+    private func emitChange() {
+        Task { @MainActor in
             onChange?()
         }
     }

--- a/Sources/NotesBridge/Services/ObsidianVaultClient.swift
+++ b/Sources/NotesBridge/Services/ObsidianVaultClient.swift
@@ -49,6 +49,18 @@ struct ObsidianVaultClient: Sendable {
         relativePath: String,
         settings: AppSettings
     ) throws -> String? {
+        try moveExportedNoteToRemoved(
+            relativePath: relativePath,
+            settings: settings,
+            occupiedRelativePaths: Set(try indexExistingNotes(settings: settings).values)
+        )
+    }
+
+    func moveExportedNoteToRemoved(
+        relativePath: String,
+        settings: AppSettings,
+        occupiedRelativePaths: Set<String>
+    ) throws -> String? {
         let fileManager = FileManager.default
         let vaultURL = try vaultURL(for: settings)
         let sourceURL = vaultURL.appendingPathComponent(relativePath)
@@ -64,7 +76,7 @@ struct ObsidianVaultClient: Sendable {
             return nil
         }
 
-        var occupiedRelativePaths = Set(try indexExistingNotes(settings: settings).values)
+        var occupiedRelativePaths = occupiedRelativePaths
         occupiedRelativePaths.remove(relativePath)
         let removedRelativePath = removedRelativePath(
             for: relativePath,

--- a/Tests/NotesBridgeTests/AppModelAutomaticSyncTests.swift
+++ b/Tests/NotesBridgeTests/AppModelAutomaticSyncTests.swift
@@ -5,6 +5,31 @@ import Testing
 struct AppModelAutomaticSyncTests {
     @MainActor
     @Test
+    func onChangeWatcherDebouncesBackgroundNotificationsWithoutDroppingLifecycleBehavior() async {
+        let watcher = ManualNotesDatabaseWatcher()
+        var settings = AppSettings.default
+        settings.appleNotesDataPath = "/tmp/group.com.apple.notes"
+        settings.automaticSyncEnabled = true
+        settings.automaticSyncTrigger = .onChange
+
+        let model = AppModel(
+            appleNotesSyncDataSource: StubAutomaticSyncDataSource(),
+            persistence: StubAutomaticSyncPersistenceStore(settings: settings),
+            appUpdater: NoOpAppUpdater(version: AppVersion(shortVersionString: "0.2.9", buildNumber: "1")),
+            notesDatabaseWatcher: watcher,
+            startImmediately: false
+        )
+
+        model.settings = settings
+        watcher.fire()
+        watcher.fire()
+
+        #expect(watcher.startCallCount == 1)
+        #expect(watcher.stopCallCount == 1)
+    }
+
+    @MainActor
+    @Test
     func onChangeWatcherRetainsDataFolderAccessSessionUntilAutomaticSyncStops() {
         let probe = AccessSessionProbe()
         var settings = AppSettings.default
@@ -109,4 +134,24 @@ private struct StubAutomaticSyncDataSource: AppleNotesSyncDataSourcing {
 private final class AccessSessionProbe: @unchecked Sendable {
     var createdCount = 0
     var stoppedCount = 0
+}
+
+private final class ManualNotesDatabaseWatcher: NotesDatabaseWatching, @unchecked Sendable {
+    var onChange: (@MainActor @Sendable () -> Void)?
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+
+    func start(dataFolderURL: URL) {
+        startCallCount += 1
+    }
+
+    func stop() {
+        stopCallCount += 1
+    }
+
+    func fire() {
+        Task { @MainActor in
+            onChange?()
+        }
+    }
 }

--- a/Tests/NotesBridgeTests/AppModelAutomaticSyncTests.swift
+++ b/Tests/NotesBridgeTests/AppModelAutomaticSyncTests.swift
@@ -7,25 +7,31 @@ struct AppModelAutomaticSyncTests {
     @Test
     func onChangeWatcherDebouncesBackgroundNotificationsWithoutDroppingLifecycleBehavior() async {
         let watcher = ManualNotesDatabaseWatcher()
+        let syncProbe = AutomaticSyncProbe()
         var settings = AppSettings.default
+        settings.vaultPath = "/tmp/notesbridge-tests"
         settings.appleNotesDataPath = "/tmp/group.com.apple.notes"
         settings.automaticSyncEnabled = true
         settings.automaticSyncTrigger = .onChange
 
         let model = AppModel(
-            appleNotesSyncDataSource: StubAutomaticSyncDataSource(),
+            appleNotesSyncDataSource: RecordingAutomaticSyncDataSource(),
+            syncEngine: RecordingAutomaticSyncEngine(probe: syncProbe),
             persistence: StubAutomaticSyncPersistenceStore(settings: settings),
             appUpdater: NoOpAppUpdater(version: AppVersion(shortVersionString: "0.2.9", buildNumber: "1")),
             notesDatabaseWatcher: watcher,
+            automaticSyncDebounceInterval: 0.05,
             startImmediately: false
         )
 
         model.settings = settings
-        watcher.fire()
-        watcher.fire()
+        await watcher.fire()
+        await watcher.fire()
+        try? await Task.sleep(nanoseconds: 250_000_000)
 
         #expect(watcher.startCallCount == 1)
         #expect(watcher.stopCallCount == 1)
+        #expect(syncProbe.syncCallCount == 1)
     }
 
     @MainActor
@@ -131,9 +137,115 @@ private struct StubAutomaticSyncDataSource: AppleNotesSyncDataSourcing {
     }
 }
 
+private struct RecordingAutomaticSyncDataSource: AppleNotesSyncDataSourcing {
+    func validateDataFolder(at path: String) throws -> AppleNotesDataFolderSelection {
+        .resolved(rootPath: path)
+    }
+
+    func inspectDataFolder(at path: String) -> AppleNotesDataFolderAccessStatus {
+        AppleNotesDataFolderAccessStatus(
+            level: .accessible,
+            message: "The configured Apple Notes data folder is readable."
+        )
+    }
+
+    func fetchFolders(fromDataFolder path: String) throws -> [AppleNotesFolder] {
+        [
+            AppleNotesFolder(id: "folder-1", name: "Inbox", accountName: nil, noteCount: 1),
+        ]
+    }
+
+    func loadManifest(fromDataFolder path: String) throws -> AppleNotesSyncManifest {
+        AppleNotesSyncManifest(
+            folders: try fetchFolders(fromDataFolder: path),
+            entries: [
+                AppleNotesSyncManifestEntry(
+                    databaseNoteID: 1,
+                    name: "Stable",
+                    folder: "Inbox",
+                    updatedAt: Date(timeIntervalSince1970: 1),
+                    passwordProtected: false,
+                    trashed: false
+                ),
+            ],
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:],
+            sourceDiagnostics: nil,
+            selectedDatabaseRelativePath: nil
+        )
+    }
+
+    func loadDocuments(
+        fromDataFolder path: String,
+        noteIDs: Set<Int64>,
+        preferredDatabaseRelativePath: String?
+    ) throws -> AppleNotesSyncSnapshot {
+        AppleNotesSyncSnapshot(
+            folders: try fetchFolders(fromDataFolder: path),
+            documents: [
+                AppleNotesSyncDocument(
+                    databaseNoteID: 1,
+                    name: "Stable",
+                    folder: "Inbox",
+                    createdAt: Date(timeIntervalSince1970: 0),
+                    updatedAt: Date(timeIntervalSince1970: 1),
+                    shared: false,
+                    passwordProtected: false,
+                    markdownTemplate: "Stable",
+                    attachments: []
+                ),
+            ],
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:]
+        )
+    }
+
+    func loadSnapshot(fromDataFolder path: String) throws -> AppleNotesSyncSnapshot {
+        try loadDocuments(
+            fromDataFolder: path,
+            noteIDs: [1],
+            preferredDatabaseRelativePath: nil
+        )
+    }
+}
+
 private final class AccessSessionProbe: @unchecked Sendable {
     var createdCount = 0
     var stoppedCount = 0
+}
+
+private final class AutomaticSyncProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var syncCallCount = 0
+
+    func recordSyncCall() {
+        lock.lock()
+        syncCallCount += 1
+        lock.unlock()
+    }
+}
+
+private struct RecordingAutomaticSyncEngine: Syncing {
+    let probe: AutomaticSyncProbe
+
+    func sync(
+        document: AppleNotesSyncDocument,
+        settings: AppSettings,
+        existingRelativePath: String?,
+        plannedRelativePath: String,
+        plannedRelativePathsBySourceIdentifier: [String: String]
+    ) throws -> NoteSyncResult {
+        probe.recordSyncCall()
+        return NoteSyncResult(
+            record: SyncRecord(
+                noteID: document.id,
+                relativePath: plannedRelativePath,
+                sourceUpdatedAt: document.updatedAt
+            ),
+            changeKind: existingRelativePath == nil ? .created : .updated,
+            unresolvedInternalLinkCount: 0
+        )
+    }
 }
 
 private final class ManualNotesDatabaseWatcher: NotesDatabaseWatching, @unchecked Sendable {
@@ -149,9 +261,9 @@ private final class ManualNotesDatabaseWatcher: NotesDatabaseWatching, @unchecke
         stopCallCount += 1
     }
 
-    func fire() {
-        Task { @MainActor in
+    func fire() async {
+        await Task { @MainActor in
             onChange?()
-        }
+        }.value
     }
 }

--- a/Tests/NotesBridgeTests/AppModelSyncProgressTests.swift
+++ b/Tests/NotesBridgeTests/AppModelSyncProgressTests.swift
@@ -190,6 +190,92 @@ struct AppModelSyncProgressTests {
     }
 
     @MainActor
+    @Test
+    func incrementalSyncWithNoExportsAndNoRemovalsSkipsChangedDocumentLoad() async {
+        var settings = AppSettings.default
+        settings.vaultPath = "/tmp/notesbridge-tests"
+        settings.appleNotesDataPath = "/tmp/group.com.apple.notes"
+
+        let dataSource = RecordingIncrementalDataSource(
+            folders: [
+                AppleNotesFolder(id: "folder-1", name: "Inbox", accountName: nil, noteCount: 1),
+            ],
+            documentsByFolderName: [
+                "Inbox": [Self.note(id: "note-1", name: "Stable", folder: "Inbox")],
+            ],
+            syncIndex: SyncIndex(
+                records: [
+                    AppleNotesSyncDocument.canonicalID(for: 1): SyncRecord(
+                        noteID: AppleNotesSyncDocument.canonicalID(for: 1),
+                        relativePath: "Apple Notes/Inbox/Stable.md",
+                        sourceUpdatedAt: nil,
+                        sourceName: "Stable",
+                        sourceFolderPath: "Inbox"
+                    ),
+                ],
+                pathAliases: [
+                    AppleNotesSyncDocument.canonicalID(for: 1): "Apple Notes/Inbox/Stable.md",
+                ]
+            )
+        )
+
+        let model = AppModel(
+            appleNotesSyncDataSource: dataSource,
+            persistence: StubPersistenceStore(settings: settings, syncIndex: dataSource.syncIndex),
+            appUpdater: makeTestAppUpdater(),
+            startImmediately: false
+        )
+
+        await model.syncChangedNotes()
+
+        #expect(dataSource.loadDocumentsCallCount == 0)
+        #expect(model.statusMessage.contains("found no changes"))
+    }
+
+    @MainActor
+    @Test
+    func noOpIncrementalSummaryShowsCachedPathIndex() async {
+        var settings = AppSettings.default
+        settings.vaultPath = "/tmp/notesbridge-tests"
+        settings.appleNotesDataPath = "/tmp/group.com.apple.notes"
+
+        let dataSource = RecordingIncrementalDataSource(
+            folders: [
+                AppleNotesFolder(id: "folder-1", name: "Inbox", accountName: nil, noteCount: 1),
+            ],
+            documentsByFolderName: [
+                "Inbox": [Self.note(id: "note-1", name: "Stable", folder: "Inbox")],
+            ],
+            syncIndex: SyncIndex(
+                records: [
+                    AppleNotesSyncDocument.canonicalID(for: 1): SyncRecord(
+                        noteID: AppleNotesSyncDocument.canonicalID(for: 1),
+                        relativePath: "Apple Notes/Inbox/Stable.md",
+                        sourceUpdatedAt: nil,
+                        sourceName: "Stable",
+                        sourceFolderPath: "Inbox"
+                    ),
+                ],
+                pathAliases: [
+                    AppleNotesSyncDocument.canonicalID(for: 1): "Apple Notes/Inbox/Stable.md",
+                ]
+            )
+        )
+
+        let model = AppModel(
+            appleNotesSyncDataSource: dataSource,
+            persistence: StubPersistenceStore(settings: settings, syncIndex: dataSource.syncIndex),
+            appUpdater: makeTestAppUpdater(),
+            startImmediately: false
+        )
+
+        await model.syncChangedNotes()
+
+        #expect(model.statusMessage.contains("index"))
+        #expect(model.statusMessage.contains("cached"))
+    }
+
+    @MainActor
     private func captureProgressSnapshots(
         from model: AppModel,
         perform operation: @escaping @MainActor () async -> Void
@@ -306,6 +392,91 @@ private struct StubAppleNotesSyncDataSource: AppleNotesSyncDataSourcing {
             documents: allDocuments.filter {
                 noteIDs.contains($0.databaseNoteID) && !missingDocumentIDsOnIncrementalLoad.contains($0.databaseNoteID)
             },
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:]
+        )
+    }
+
+    func loadSnapshot(fromDataFolder path: String) throws -> AppleNotesSyncSnapshot {
+        AppleNotesSyncSnapshot(
+            folders: folders,
+            documents: folders.flatMap { documentsByFolderName[$0.displayName] ?? [] },
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:]
+        )
+    }
+}
+
+private final class RecordingIncrementalDataSource: AppleNotesSyncDataSourcing, @unchecked Sendable {
+    let folders: [AppleNotesFolder]
+    let documentsByFolderName: [String: [AppleNotesSyncDocument]]
+    let syncIndex: SyncIndex
+
+    private let lock = NSLock()
+    private(set) var loadDocumentsCallCount = 0
+
+    init(
+        folders: [AppleNotesFolder],
+        documentsByFolderName: [String: [AppleNotesSyncDocument]],
+        syncIndex: SyncIndex
+    ) {
+        self.folders = folders
+        self.documentsByFolderName = documentsByFolderName
+        self.syncIndex = syncIndex
+    }
+
+    func validateDataFolder(at path: String) throws -> AppleNotesDataFolderSelection {
+        .resolved(rootPath: path)
+    }
+
+    func inspectDataFolder(at path: String) -> AppleNotesDataFolderAccessStatus {
+        AppleNotesDataFolderAccessStatus(
+            level: .accessible,
+            message: "The configured Apple Notes data folder is readable."
+        )
+    }
+
+    func fetchFolders(fromDataFolder path: String) throws -> [AppleNotesFolder] {
+        folders
+    }
+
+    func loadManifest(fromDataFolder path: String) throws -> AppleNotesSyncManifest {
+        let documents = folders.flatMap { documentsByFolderName[$0.displayName] ?? [] }
+        return AppleNotesSyncManifest(
+            folders: folders,
+            entries: documents.map { document in
+                AppleNotesSyncManifestEntry(
+                    databaseNoteID: document.databaseNoteID,
+                    sourceNoteIdentifier: document.sourceNoteIdentifierRaw,
+                    folderDatabaseID: document.folderDatabaseID,
+                    name: document.name,
+                    folder: document.folder,
+                    folderPath: document.folderPath,
+                    updatedAt: document.updatedAt,
+                    passwordProtected: document.passwordProtected,
+                    trashed: false
+                )
+            },
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:],
+            sourceDiagnostics: nil,
+            selectedDatabaseRelativePath: nil
+        )
+    }
+
+    func loadDocuments(
+        fromDataFolder path: String,
+        noteIDs: Set<Int64>,
+        preferredDatabaseRelativePath: String?
+    ) throws -> AppleNotesSyncSnapshot {
+        lock.lock()
+        loadDocumentsCallCount += 1
+        lock.unlock()
+
+        let allDocuments = folders.flatMap { documentsByFolderName[$0.displayName] ?? [] }
+        return AppleNotesSyncSnapshot(
+            folders: folders,
+            documents: allDocuments.filter { noteIDs.contains($0.databaseNoteID) },
             skippedLockedNotes: 0,
             skippedLockedNotesByFolder: [:]
         )

--- a/Tests/NotesBridgeTests/IncrementalSyncPlannerTests.swift
+++ b/Tests/NotesBridgeTests/IncrementalSyncPlannerTests.swift
@@ -99,6 +99,35 @@ struct IncrementalSyncPlannerTests {
         #expect(plan.unchangedNoteCount == 1)
     }
 
+    @Test
+    func prefersPersistedPathAliasesBeforeRecoveryScanResults() {
+        let manifest = AppleNotesSyncManifest(
+            folders: [],
+            entries: [entry(id: 7, name: "Stable", folder: "Inbox", updatedAt: date(700))],
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:],
+            sourceDiagnostics: nil
+        )
+        let syncIndex = SyncIndex(
+            records: [:],
+            pathAliases: [
+                AppleNotesSyncDocument.canonicalID(for: 7): "Apple Notes/Inbox/Stable.md",
+                "x-coredata://example/ICNote/p7": "Apple Notes/Inbox/Stable.md",
+            ]
+        )
+
+        let plan = planner.plan(
+            manifest: manifest,
+            syncIndex: syncIndex,
+            indexedRelativePaths: [
+                AppleNotesSyncDocument.canonicalID(for: 7): "Apple Notes/Inbox/Recovered.md",
+            ],
+            settings: .default
+        )
+
+        #expect(plan.exports.first?.existingRelativePath == "Apple Notes/Inbox/Stable.md")
+    }
+
     private func entry(
         id: Int64,
         name: String,

--- a/Tests/NotesBridgeTests/NotesDatabaseWatcherTests.swift
+++ b/Tests/NotesBridgeTests/NotesDatabaseWatcherTests.swift
@@ -13,7 +13,7 @@ final class NotesDatabaseWatcherTests: XCTestCase {
         try "initial".write(to: dbURL, atomically: true, encoding: .utf8)
 
         let expectation = expectation(description: "Change detected")
-        let watcher = NotesDatabaseWatcher()
+        let watcher = NotesDatabaseWatcher(pollInterval: 0.2)
         defer { watcher.stop() }
 
         watcher.onChange = {
@@ -23,13 +23,12 @@ final class NotesDatabaseWatcherTests: XCTestCase {
         watcher.start(dataFolderURL: tempDir)
 
         // Wait for first poll to record initial dates
-        try await Task.sleep(nanoseconds: 2_500_000_000)
+        try await Task.sleep(nanoseconds: 300_000_000)
 
         // Modify file
         try "changed".write(to: dbURL, atomically: true, encoding: .utf8)
 
-        // Poll interval is 2s, wait enough time
-        await fulfillment(of: [expectation], timeout: 5.0)
+        await fulfillment(of: [expectation], timeout: 2.0)
     }
 
     func testWatcherDetectsFirstPostBaselineWALCreation() async throws {

--- a/Tests/NotesBridgeTests/ObsidianVaultClientTests.swift
+++ b/Tests/NotesBridgeTests/ObsidianVaultClientTests.swift
@@ -809,6 +809,36 @@ struct ObsidianVaultClientTests {
         )
     }
 
+    @Test
+    func movesDeletedNotesUsingSharedOccupiedPaths() throws {
+        let vaultURL = try makeTemporaryVault()
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        var settings = AppSettings.default
+        settings.vaultPath = vaultURL.path
+
+        let note = AppleNotesSyncDocument(
+            databaseNoteID: 22,
+            name: "Deleted",
+            folder: "Inbox",
+            createdAt: nil,
+            updatedAt: nil,
+            shared: false,
+            passwordProtected: false,
+            markdownTemplate: "Body",
+            attachments: []
+        )
+        let export = try client.export(note: note, settings: settings, existingRelativePath: nil)
+
+        let removedRelativePath = try client.moveExportedNoteToRemoved(
+            relativePath: export.relativePath,
+            settings: settings,
+            occupiedRelativePaths: ["Apple Notes/_Removed/Inbox/Deleted.md"]
+        )
+
+        #expect(removedRelativePath == "Apple Notes/_Removed/Inbox/Deleted 2.md")
+    }
+
     private func note(
         named title: String,
         in folder: String,

--- a/Tests/NotesBridgeTests/SyncIndexTests.swift
+++ b/Tests/NotesBridgeTests/SyncIndexTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import NotesBridge
+
+struct SyncIndexTests {
+    @Test
+    func defaultsPathAliasesToEmptyWhenDecodingOlderPayloads() throws {
+        let json = """
+        {
+          "records": {},
+          "lastSyncMode": "incremental"
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SyncIndex.self, from: json)
+
+        #expect(decoded.pathAliases.isEmpty)
+    }
+
+    @Test
+    func roundTripsPathAliasesThroughCodable() throws {
+        let index = SyncIndex(
+            records: [:],
+            pathAliases: [
+                "apple-notes-db://note/42": "Apple Notes/Inbox/Roadmap.md",
+                "x-coredata://legacy/ICNote/p42": "Apple Notes/Inbox/Roadmap.md",
+            ]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(index)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SyncIndex.self, from: data)
+
+        #expect(decoded.pathAliases == index.pathAliases)
+    }
+}


### PR DESCRIPTION
## Why
Incremental and automatic sync were still doing full-vault style work for small or no-op changes. That made sync latency scale with vault size instead of the actual user-visible change.

Closes #27.

## Root cause
- `SyncIndex` did not persist note identifier -> relative path aliases, so normal sync execution had to recover paths by rescanning the exported vault.
- Incremental sync continued into changed-document loading even when the planner produced no exports or removals, and removed-note handling rebuilt occupied path state repeatedly.
- Change-triggered monitoring used a polling loop scheduled on the main actor, so idle watching still consumed main-thread work.

## What changed
- Persist `pathAliases` in `SyncIndex` and decode older payloads compatibly.
- Prefer persisted aliases during planning and sync execution, falling back to recovery scans only when aliases are missing.
- Short-circuit no-op incremental syncs before changed-document loading.
- Reuse shared occupied-path state when moving removed notes into `_Removed`.
- Move the database watcher loop off the main actor and make watcher creation injectable for lifecycle/debounce tests.
- Extend sync timing output so index timings show whether paths came from cached aliases or recovery.

## Tests
- `swift test`
- `xcodebuild -scheme NotesBridge -workspace .swiftpm/xcode/package.xcworkspace -destination 'platform=macOS' test`\n\n## Risks / rollback\n- Cached aliases can still become stale if a note path drifts outside the normal sync flow; the code only falls back to recovery when aliases are missing, not when an existing alias silently points at an outdated path.\n- The watcher is still polling-based; this change removes main-thread polling cost but does not replace polling with file events.\n- Roll back by reverting commits `0ab436b`, `2486c38`, and `854699e` if the cached-alias path causes regressions.