### PR TITLE
Fix Sonoma folder picker presentation

### DIFF
--- a/Sources/NotesBridge/App/AppModel.swift
+++ b/Sources/NotesBridge/App/AppModel.swift
@@ -115,6 +115,7 @@ final class AppModel: ObservableObject {
     private let notesClient: any AppleNotesClient
     private let appleNotesSyncDataSource: any AppleNotesSyncDataSourcing
     private let appleNotesDataFolderSelector: any AppleNotesDataFolderSelecting
+    private let vaultDirectorySelector: any VaultDirectorySelecting
     private let incrementalSyncPlanner: IncrementalSyncPlanner
     private let syncEngine: any Syncing
     private let vaultClient: ObsidianVaultClient
@@ -142,6 +143,7 @@ final class AppModel: ObservableObject {
         notesClient: any AppleNotesClient = AppleNotesScriptClient(),
         appleNotesSyncDataSource: any AppleNotesSyncDataSourcing = AppleNotesDatabaseSyncSource(),
         appleNotesDataFolderSelector: any AppleNotesDataFolderSelecting = AppleNotesDataFolderSelector(),
+        vaultDirectorySelector: any VaultDirectorySelecting = ObsidianVaultDirectorySelector(),
         incrementalSyncPlanner: IncrementalSyncPlanner = IncrementalSyncPlanner(),
         syncEngine: any Syncing = SyncEngine(),
         vaultClient: ObsidianVaultClient = ObsidianVaultClient(),
@@ -161,6 +163,7 @@ final class AppModel: ObservableObject {
         self.notesClient = notesClient
         self.appleNotesSyncDataSource = appleNotesSyncDataSource
         self.appleNotesDataFolderSelector = appleNotesDataFolderSelector
+        self.vaultDirectorySelector = vaultDirectorySelector
         self.incrementalSyncPlanner = incrementalSyncPlanner
         self.syncEngine = syncEngine
         self.vaultClient = vaultClient
@@ -523,15 +526,12 @@ final class AppModel: ObservableObject {
     }
 
     func chooseVaultDirectory() {
-        let panel = NSOpenPanel()
-        panel.title = t("Choose an Obsidian vault")
-        panel.prompt = t("Use Vault")
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.canCreateDirectories = true
-
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard let url = vaultDirectorySelector.chooseVaultDirectory(
+            title: t("Choose an Obsidian vault"),
+            prompt: t("Use Vault")
+        ) else {
+            return
+        }
         settings.vaultPath = url.path
         statusMessage = tf("Obsidian vault set to %@.", url.lastPathComponent)
     }

--- a/Sources/NotesBridge/Services/AppleNotesDatabaseSyncSource.swift
+++ b/Sources/NotesBridge/Services/AppleNotesDatabaseSyncSource.swift
@@ -20,24 +20,16 @@ protocol AppleNotesDataFolderSelecting {
     func chooseAppleNotesDataFolder() -> URL?
 }
 
-@MainActor
 struct AppleNotesDataFolderSelector: AppleNotesDataFolderSelecting {
+    @MainActor
     func chooseAppleNotesDataFolder() -> URL? {
-        let panel = NSOpenPanel()
-        panel.title = "Choose Apple Notes Data Folder"
-        panel.prompt = "Use Folder"
-        panel.message = "Select the \"group.com.apple.notes\" folder to allow NotesBridge to read Apple Notes data."
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.canCreateDirectories = false
-        panel.directoryURL = defaultAppleNotesDataFolderURL()
-
-        guard panel.runModal() == .OK else {
-            return nil
-        }
-
-        return panel.url
+        AppKitDirectoryPanel().chooseDirectory(
+            title: "Choose Apple Notes Data Folder",
+            prompt: "Use Folder",
+            message: "Select the \"group.com.apple.notes\" folder to allow NotesBridge to read Apple Notes data.",
+            directoryURL: defaultAppleNotesDataFolderURL(),
+            canCreateDirectories: false
+        )
     }
 
     func defaultAppleNotesDataFolderURL(fileManager: FileManager = .default) -> URL {

--- a/Sources/NotesBridge/Support/AppKitDirectoryPanel.swift
+++ b/Sources/NotesBridge/Support/AppKitDirectoryPanel.swift
@@ -1,0 +1,111 @@
+import AppKit
+import Foundation
+
+@MainActor
+protocol AppKitDirectoryPanelApplication {
+    func currentActivationPolicy() -> NSApplication.ActivationPolicy
+    @discardableResult func setActivationPolicy(_ policy: NSApplication.ActivationPolicy) -> Bool
+    func activateIgnoringOtherApps()
+    func bringDirectoryPanelParentWindowForward()
+}
+
+@MainActor
+struct LiveAppKitDirectoryPanelApplication: AppKitDirectoryPanelApplication {
+    func currentActivationPolicy() -> NSApplication.ActivationPolicy {
+        NSApp.activationPolicy()
+    }
+
+    @discardableResult
+    func setActivationPolicy(_ policy: NSApplication.ActivationPolicy) -> Bool {
+        NSApp.setActivationPolicy(policy)
+    }
+
+    func activateIgnoringOtherApps() {
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func bringDirectoryPanelParentWindowForward() {
+        let parentWindow = NSApp.keyWindow
+            ?? NSApp.mainWindow
+            ?? NSApp.windows.first { window in
+                window.isVisible && !window.isMiniaturized
+            }
+        parentWindow?.makeKeyAndOrderFront(nil)
+    }
+}
+
+@MainActor
+struct AppKitDirectoryPanel {
+    typealias PanelRunner = @MainActor (NSOpenPanel) -> NSApplication.ModalResponse
+
+    private let application: any AppKitDirectoryPanelApplication
+    private let panelRunner: PanelRunner
+
+    init(
+        application: any AppKitDirectoryPanelApplication = LiveAppKitDirectoryPanelApplication(),
+        panelRunner: @escaping PanelRunner = { panel in panel.runModal() }
+    ) {
+        self.application = application
+        self.panelRunner = panelRunner
+    }
+
+    func chooseDirectory(
+        title: String,
+        prompt: String,
+        message: String? = nil,
+        directoryURL: URL? = nil,
+        canCreateDirectories: Bool
+    ) -> URL? {
+        let panel = NSOpenPanel()
+        panel.title = title
+        panel.prompt = prompt
+        panel.message = message ?? ""
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = canCreateDirectories
+        panel.directoryURL = directoryURL
+
+        let shouldRestoreAccessoryPolicy = application.currentActivationPolicy() == .accessory
+        let changedActivationPolicy = shouldRestoreAccessoryPolicy
+            ? application.setActivationPolicy(.regular)
+            : false
+
+        application.activateIgnoringOtherApps()
+        application.bringDirectoryPanelParentWindowForward()
+
+        defer {
+            if changedActivationPolicy {
+                application.setActivationPolicy(.accessory)
+            }
+        }
+
+        guard panelRunner(panel) == .OK else {
+            return nil
+        }
+
+        return panel.url
+    }
+}
+
+@MainActor
+protocol VaultDirectorySelecting {
+    func chooseVaultDirectory(title: String, prompt: String) -> URL?
+}
+
+@MainActor
+struct ObsidianVaultDirectorySelector: VaultDirectorySelecting {
+    private let directoryPanel: AppKitDirectoryPanel
+
+    init(directoryPanel: AppKitDirectoryPanel = AppKitDirectoryPanel()) {
+        self.directoryPanel = directoryPanel
+    }
+
+    func chooseVaultDirectory(title: String, prompt: String) -> URL? {
+        directoryPanel.chooseDirectory(
+            title: title,
+            prompt: prompt,
+            canCreateDirectories: true
+        )
+    }
+}

--- a/Tests/NotesBridgeTests/AppModelDirectorySelectionTests.swift
+++ b/Tests/NotesBridgeTests/AppModelDirectorySelectionTests.swift
@@ -1,0 +1,249 @@
+import AppKit
+import Foundation
+import Testing
+@testable import NotesBridge
+
+struct AppModelDirectorySelectionTests {
+    @MainActor
+    @Test
+    func vaultChooserPersistsSelectedPathAndStatusMessage() throws {
+        let vaultURL = try makeTemporaryDirectory(named: "vault")
+        defer { try? FileManager.default.removeItem(at: vaultURL.deletingLastPathComponent()) }
+
+        let model = AppModel(
+            appleNotesSyncDataSource: DirectorySelectionDataSource(),
+            appleNotesDataFolderSelector: StubAppleNotesDataFolderSelector(url: nil),
+            vaultDirectorySelector: StubVaultDirectorySelector(url: vaultURL),
+            persistence: DirectorySelectionPersistenceStore(),
+            appUpdater: NoOpAppUpdater(version: AppVersion(shortVersionString: "0.2.10", buildNumber: "1")),
+            startImmediately: false
+        )
+
+        model.chooseVaultDirectory()
+
+        #expect(model.settings.vaultPath == vaultURL.path)
+        #expect(model.statusMessage == "Obsidian vault set to vault.")
+    }
+
+    @MainActor
+    @Test
+    func vaultChooserDoesNothingWhenSelectionIsCancelled() {
+        let model = AppModel(
+            appleNotesSyncDataSource: DirectorySelectionDataSource(),
+            appleNotesDataFolderSelector: StubAppleNotesDataFolderSelector(url: nil),
+            vaultDirectorySelector: StubVaultDirectorySelector(url: nil),
+            persistence: DirectorySelectionPersistenceStore(),
+            appUpdater: NoOpAppUpdater(version: AppVersion(shortVersionString: "0.2.10", buildNumber: "1")),
+            startImmediately: false
+        )
+
+        model.chooseVaultDirectory()
+
+        #expect(model.settings.vaultPath == nil)
+        #expect(model.statusMessage == "Ready")
+    }
+
+    @MainActor
+    @Test
+    func appleNotesChooserPersistsValidatedSelectionAndBookmark() throws {
+        let dataFolderURL = try makeTemporaryDirectory(named: "group.com.apple.notes")
+        defer { try? FileManager.default.removeItem(at: dataFolderURL.deletingLastPathComponent()) }
+
+        let model = AppModel(
+            appleNotesSyncDataSource: DirectorySelectionDataSource(),
+            appleNotesDataFolderSelector: StubAppleNotesDataFolderSelector(url: dataFolderURL),
+            vaultDirectorySelector: StubVaultDirectorySelector(url: nil),
+            persistence: DirectorySelectionPersistenceStore(),
+            appUpdater: NoOpAppUpdater(version: AppVersion(shortVersionString: "0.2.10", buildNumber: "1")),
+            startImmediately: false
+        )
+
+        model.chooseAppleNotesDataFolder()
+
+        #expect(model.settings.appleNotesDataPath == dataFolderURL.path)
+        #expect(model.settings.appleNotesDataBookmark != nil)
+        #expect(model.statusMessage == "Apple Notes data folder set to group.com.apple.notes.")
+    }
+
+    @MainActor
+    @Test
+    func appleNotesChooserDoesNothingWhenSelectionIsCancelled() {
+        let model = AppModel(
+            appleNotesSyncDataSource: DirectorySelectionDataSource(),
+            appleNotesDataFolderSelector: StubAppleNotesDataFolderSelector(url: nil),
+            vaultDirectorySelector: StubVaultDirectorySelector(url: nil),
+            persistence: DirectorySelectionPersistenceStore(),
+            appUpdater: NoOpAppUpdater(version: AppVersion(shortVersionString: "0.2.10", buildNumber: "1")),
+            startImmediately: false
+        )
+
+        model.chooseAppleNotesDataFolder()
+
+        #expect(model.settings.appleNotesDataPath == nil)
+        #expect(model.settings.appleNotesDataBookmark == nil)
+        #expect(model.statusMessage == "Ready")
+    }
+
+    @MainActor
+    @Test
+    func directoryPanelTemporarilyPromotesAccessoryAppAndRestoresIt() {
+        let application = RecordingDirectoryPanelApplication(initialPolicy: .accessory)
+        let panel = AppKitDirectoryPanel(application: application) { _ in .cancel }
+
+        _ = panel.chooseDirectory(
+            title: "Choose Folder",
+            prompt: "Use Folder",
+            canCreateDirectories: false
+        )
+
+        #expect(application.events == [
+            .setActivationPolicy(.regular),
+            .activateIgnoringOtherApps,
+            .bringDirectoryPanelParentWindowForward,
+            .setActivationPolicy(.accessory),
+        ])
+    }
+
+    @MainActor
+    @Test
+    func directoryPanelDoesNotRestorePolicyWhenAppIsAlreadyRegular() {
+        let application = RecordingDirectoryPanelApplication(initialPolicy: .regular)
+        let panel = AppKitDirectoryPanel(application: application) { _ in .cancel }
+
+        _ = panel.chooseDirectory(
+            title: "Choose Folder",
+            prompt: "Use Folder",
+            canCreateDirectories: false
+        )
+
+        #expect(application.events == [
+            .activateIgnoringOtherApps,
+            .bringDirectoryPanelParentWindowForward,
+        ])
+    }
+}
+
+private func makeTemporaryDirectory(named name: String) throws -> URL {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("NotesBridge-DirectorySelection-\(UUID().uuidString)", isDirectory: true)
+    let directoryURL = rootURL.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    return directoryURL
+}
+
+@MainActor
+private struct StubVaultDirectorySelector: VaultDirectorySelecting {
+    let url: URL?
+
+    func chooseVaultDirectory(title: String, prompt: String) -> URL? {
+        url
+    }
+}
+
+@MainActor
+private struct StubAppleNotesDataFolderSelector: AppleNotesDataFolderSelecting {
+    let url: URL?
+
+    func chooseAppleNotesDataFolder() -> URL? {
+        url
+    }
+}
+
+private struct DirectorySelectionPersistenceStore: PersistenceStoring {
+    func loadSettings() -> AppSettings {
+        AppSettings.default
+    }
+
+    func saveSettings(_ settings: AppSettings) throws {}
+
+    func loadSyncIndex() -> SyncIndex {
+        SyncIndex()
+    }
+
+    func saveSyncIndex(_ index: SyncIndex) throws {}
+}
+
+private struct DirectorySelectionDataSource: AppleNotesSyncDataSourcing {
+    func validateDataFolder(at path: String) throws -> AppleNotesDataFolderSelection {
+        .resolved(rootPath: path, databaseRelativePath: "NoteStore.sqlite")
+    }
+
+    func inspectDataFolder(at path: String) -> AppleNotesDataFolderAccessStatus {
+        AppleNotesDataFolderAccessStatus(
+            level: .accessible,
+            message: "The configured Apple Notes data folder is readable."
+        )
+    }
+
+    func fetchFolders(fromDataFolder path: String) throws -> [AppleNotesFolder] {
+        []
+    }
+
+    func loadManifest(fromDataFolder path: String) throws -> AppleNotesSyncManifest {
+        AppleNotesSyncManifest(
+            folders: [],
+            entries: [],
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:],
+            sourceDiagnostics: nil,
+            selectedDatabaseRelativePath: nil
+        )
+    }
+
+    func loadDocuments(
+        fromDataFolder path: String,
+        noteIDs: Set<Int64>,
+        preferredDatabaseRelativePath: String?
+    ) throws -> AppleNotesSyncSnapshot {
+        AppleNotesSyncSnapshot(
+            folders: [],
+            documents: [],
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:]
+        )
+    }
+
+    func loadSnapshot(fromDataFolder path: String) throws -> AppleNotesSyncSnapshot {
+        AppleNotesSyncSnapshot(
+            folders: [],
+            documents: [],
+            skippedLockedNotes: 0,
+            skippedLockedNotesByFolder: [:]
+        )
+    }
+}
+
+@MainActor
+private final class RecordingDirectoryPanelApplication: AppKitDirectoryPanelApplication {
+    private var policy: NSApplication.ActivationPolicy
+    private(set) var events: [Event] = []
+
+    init(initialPolicy: NSApplication.ActivationPolicy) {
+        self.policy = initialPolicy
+    }
+
+    func currentActivationPolicy() -> NSApplication.ActivationPolicy {
+        policy
+    }
+
+    @discardableResult
+    func setActivationPolicy(_ policy: NSApplication.ActivationPolicy) -> Bool {
+        events.append(.setActivationPolicy(policy))
+        self.policy = policy
+        return true
+    }
+
+    func activateIgnoringOtherApps() {
+        events.append(.activateIgnoringOtherApps)
+    }
+
+    func bringDirectoryPanelParentWindowForward() {
+        events.append(.bringDirectoryPanelParentWindowForward)
+    }
+
+    enum Event: Equatable {
+        case setActivationPolicy(NSApplication.ActivationPolicy)
+        case activateIgnoringOtherApps
+        case bringDirectoryPanelParentWindowForward
+    }
+}


### PR DESCRIPTION
## Summary
- Fix shared AppKit directory picker presentation for accessory-mode bundled app launches.
- Route both Obsidian vault and Apple Notes data folder selection through the shared picker helper.
- Add AppModel selection tests and activation-policy tests for the accessory-to-regular-to-accessory path.

## Root cause
Issue #31 points to both setup selectors failing in the installed Sonoma app. Both flows previously ran `NSOpenPanel.runModal()` directly while the app uses accessory activation policy, making the modal presentation path the shared suspect.

## Validation
- `swift test`
- `xcodebuild -scheme NotesBridge -workspace .swiftpm/xcode/package.xcworkspace -destination 'platform=macOS' test`
- `./scripts/notesbridge.sh dev`

## Notes
- Local verification ran on macOS 26.3.1. Sonoma 14.4.1 confirmation still needs a real Sonoma run.
- Closes #31.
