### PR TITLE
Polish inline toolbar glass surfaces

### DIFF
--- a/Sources/NotesBridge/Interaction/ContextualSurfaceController.swift
+++ b/Sources/NotesBridge/Interaction/ContextualSurfaceController.swift
@@ -70,7 +70,7 @@ class ContextualSurfaceController {
         panel.level = .floating
         panel.isFloatingPanel = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
-        panel.hasShadow = true
+        panel.hasShadow = false
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hidesOnDeactivate = false

--- a/Sources/NotesBridge/Interaction/FloatingFormattingBarController.swift
+++ b/Sources/NotesBridge/Interaction/FloatingFormattingBarController.swift
@@ -29,7 +29,7 @@ final class FloatingFormattingBarController: ContextualSurfaceController {
             self?.hide()
         }
 
-        let size = hostingController?.view.fittingSize ?? CGSize(width: 420, height: 46)
+        let size = FormattingBarLayout.preferredSize(for: commands)
         update(rootView: rootView, anchorRect: selectionContext.selectionRect, size: size, preferredEdge: .maxY)
     }
 }

--- a/Sources/NotesBridge/Interaction/FloatingToolPaletteStyle.swift
+++ b/Sources/NotesBridge/Interaction/FloatingToolPaletteStyle.swift
@@ -39,7 +39,23 @@ extension View {
         self
             .padding(.horizontal, FloatingToolPaletteStyle.containerHorizontalPadding)
             .padding(.vertical, FloatingToolPaletteStyle.containerVerticalPadding)
-            .notesBridgeGlassCard(cornerRadius: FloatingToolPaletteStyle.containerCornerRadius)
+            .background(
+                .thinMaterial,
+                in: RoundedRectangle(
+                    cornerRadius: FloatingToolPaletteStyle.containerCornerRadius,
+                    style: .continuous
+                )
+            )
+            .overlay {
+                RoundedRectangle(
+                    cornerRadius: FloatingToolPaletteStyle.containerCornerRadius,
+                    style: .continuous
+                )
+                .strokeBorder(
+                    Color.white.opacity(NotesBridgeGlassStyle.borderOpacity),
+                    lineWidth: 0.8
+                )
+            }
             .padding(FloatingToolPaletteStyle.outerPadding)
     }
 }

--- a/Sources/NotesBridge/Interaction/FormattingBarLayout.swift
+++ b/Sources/NotesBridge/Interaction/FormattingBarLayout.swift
@@ -1,0 +1,95 @@
+import CoreGraphics
+import Foundation
+
+enum FormattingBarLayout {
+    enum CommandCluster {
+        case typography
+        case emphasis
+        case lists
+        case blocks
+    }
+
+    static let buttonSize: CGFloat = 34
+    static let buttonSpacing: CGFloat = 5
+    static let separatorSpacing: CGFloat = 10
+    static let separatorWidth: CGFloat = 1
+    static let horizontalPadding: CGFloat = 12
+    static let verticalPadding: CGFloat = 8
+    static let outerPadding: CGFloat = 2
+
+    static let minimumWidth: CGFloat = 160
+    static let maximumWidth: CGFloat = 464
+    static let surfaceHeight: CGFloat = 56
+    static let height: CGFloat = surfaceHeight + (outerPadding * 2)
+
+    static let containerCornerRadius: CGFloat = 20
+    static let buttonCornerRadius: CGFloat = 11
+
+    static func groups(for commands: [FormattingCommand]) -> [[FormattingCommand]] {
+        guard let first = commands.first else { return [] }
+
+        var groups: [[FormattingCommand]] = [[first]]
+        var lastCluster = cluster(for: first)
+
+        for command in commands.dropFirst() {
+            let currentCluster = cluster(for: command)
+            if currentCluster == lastCluster {
+                groups[groups.count - 1].append(command)
+            } else {
+                groups.append([command])
+                lastCluster = currentCluster
+            }
+        }
+
+        return groups
+    }
+
+    static func preferredSize(for commands: [FormattingCommand]) -> CGSize {
+        let surfaceSize = surfaceSize(for: commands)
+        return CGSize(
+            width: surfaceSize.width + (outerPadding * 2),
+            height: surfaceSize.height + (outerPadding * 2)
+        )
+    }
+
+    static func surfaceSize(for commands: [FormattingCommand]) -> CGSize {
+        let contentWidth = contentWidth(for: groups(for: commands))
+        let width = min(
+            max(contentWidth + (horizontalPadding * 2), minimumWidth - (outerPadding * 2)),
+            maximumWidth - (outerPadding * 2)
+        )
+        return CGSize(width: width, height: surfaceHeight)
+    }
+
+    static func cluster(for command: FormattingCommand) -> CommandCluster {
+        switch command {
+        case .title, .heading, .subheading, .body:
+            .typography
+        case .bold, .strikethrough, .insertLink:
+            .emphasis
+        case .checklist, .bulletedList, .dashedList, .numberedList:
+            .lists
+        case .quote, .monostyled, .table:
+            .blocks
+        }
+    }
+
+    private static func contentWidth(for groups: [[FormattingCommand]]) -> CGFloat {
+        guard !groups.isEmpty else { return minimumWidth }
+
+        var width: CGFloat = 0
+
+        for (groupIndex, group) in groups.enumerated() {
+            width += CGFloat(group.count) * buttonSize
+            if group.count > 1 {
+                width += CGFloat(group.count - 1) * buttonSpacing
+            }
+
+            if groupIndex < groups.count - 1 {
+                width += (separatorSpacing * 2) + separatorWidth
+            }
+        }
+
+        return width
+    }
+}

--- a/Sources/NotesBridge/Interaction/FormattingBarView.swift
+++ b/Sources/NotesBridge/Interaction/FormattingBarView.swift
@@ -6,18 +6,163 @@ struct FormattingBarView: View {
     let onCommand: (FormattingCommand) -> Void
 
     var body: some View {
-        HStack(spacing: 2) {
-            ForEach(commands) { command in
-                Button {
-                    onCommand(command)
-                } label: {
-                    FloatingToolPaletteIcon(systemImage: command.systemImage)
+        let groups = FormattingBarLayout.groups(for: commands)
+        let surfaceSize = FormattingBarLayout.surfaceSize(for: commands)
+
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                Spacer(minLength: 0)
+
+                HStack(spacing: 0) {
+                    ForEach(Array(groups.enumerated()), id: \.offset) { index, group in
+                        HStack(spacing: FormattingBarLayout.buttonSpacing) {
+                            ForEach(group) { command in
+                                FormattingBarCommandButton(command: command, localization: localization, onCommand: onCommand)
+                            }
+                        }
+
+                        if index < groups.count - 1 {
+                            FormattingBarSeparator()
+                                .padding(.horizontal, FormattingBarLayout.separatorSpacing)
+                        }
+                    }
                 }
-                .buttonStyle(.plain)
-                .help(localization.text(command.titleKey))
-                .accessibilityLabel(localization.text(command.titleKey))
+                .frame(
+                    minWidth: max(
+                        FormattingBarLayout.minimumWidth - (FormattingBarLayout.horizontalPadding * 2),
+                        0
+                    ),
+                    alignment: .center
+                )
+
+                Spacer(minLength: 0)
             }
+            .padding(.horizontal, FormattingBarLayout.horizontalPadding)
+            .padding(.vertical, FormattingBarLayout.verticalPadding)
         }
-        .floatingToolPaletteContainer()
+        .frame(
+            width: surfaceSize.width,
+            height: surfaceSize.height
+        )
+        .background {
+            RoundedRectangle(cornerRadius: FormattingBarLayout.containerCornerRadius, style: .continuous)
+                .fill(.ultraThinMaterial)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: FormattingBarLayout.containerCornerRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.34), lineWidth: 0.8)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: FormattingBarLayout.containerCornerRadius, style: .continuous)
+                .strokeBorder(Color.black.opacity(0.08), lineWidth: 0.5)
+                .padding(0.5)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: FormattingBarLayout.containerCornerRadius, style: .continuous))
+        .padding(FormattingBarLayout.outerPadding)
+    }
+}
+
+private struct FormattingBarCommandButton: View {
+    let command: FormattingCommand
+    let localization: AppLocalization
+    let onCommand: (FormattingCommand) -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button {
+            onCommand(command)
+        } label: {
+            Image(systemName: command.systemImage)
+                .font(.system(size: 14.5, weight: .semibold))
+                .frame(
+                    width: FormattingBarLayout.buttonSize,
+                    height: FormattingBarLayout.buttonSize
+                )
+                .contentShape(
+                    RoundedRectangle(
+                        cornerRadius: FormattingBarLayout.buttonCornerRadius,
+                        style: .continuous
+                    )
+                )
+        }
+        .buttonStyle(FormattingBarCommandButtonStyle(isHovering: isHovering))
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .help(localization.text(command.titleKey))
+        .accessibilityLabel(localization.text(command.titleKey))
+    }
+}
+
+private struct FormattingBarCommandButtonStyle: ButtonStyle {
+    let isHovering: Bool
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        let fillOpacity: CGFloat = if !isEnabled {
+            0.06
+        } else if configuration.isPressed {
+            0.24
+        } else if isHovering {
+            0.14
+        } else {
+            0
+        }
+
+        let strokeOpacity: CGFloat = if !isEnabled {
+            0.08
+        } else if configuration.isPressed {
+            0.18
+        } else if isHovering {
+            0.12
+        } else {
+            0
+        }
+
+        return configuration.label
+            .foregroundStyle(Color.primary.opacity(isEnabled ? 0.92 : 0.42))
+            .background {
+                RoundedRectangle(
+                    cornerRadius: FormattingBarLayout.buttonCornerRadius,
+                    style: .continuous
+                )
+                .fill(Color.white.opacity(fillOpacity))
+            }
+            .overlay {
+                RoundedRectangle(
+                    cornerRadius: FormattingBarLayout.buttonCornerRadius,
+                    style: .continuous
+                )
+                .strokeBorder(Color.white.opacity(strokeOpacity), lineWidth: 0.8)
+            }
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            .animation(.easeOut(duration: 0.14), value: isHovering)
+    }
+}
+
+private struct FormattingBarSeparator: View {
+    var body: some View {
+        Capsule(style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        Color.white.opacity(0.06),
+                        Color.white.opacity(0.22),
+                        Color.white.opacity(0.06),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .frame(width: FormattingBarLayout.separatorWidth, height: 22)
+            .overlay(alignment: .trailing) {
+                Capsule(style: .continuous)
+                    .fill(Color.black.opacity(0.08))
+                    .frame(width: 1, height: 22)
+                    .offset(x: 0.5)
+            }
     }
 }

--- a/Sources/NotesBridge/Interaction/SlashCommandMenuController.swift
+++ b/Sources/NotesBridge/Interaction/SlashCommandMenuController.swift
@@ -70,7 +70,7 @@ final class SlashCommandMenuController: ContextualSurfaceController {
         panel.isFloatingPanel = true
         panel.becomesKeyOnlyIfNeeded = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
-        panel.hasShadow = true
+        panel.hasShadow = false
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hidesOnDeactivate = false

--- a/Sources/NotesBridge/Views/MenuBarIconView.swift
+++ b/Sources/NotesBridge/Views/MenuBarIconView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct MenuBarIconView: View {
@@ -7,83 +6,16 @@ struct MenuBarIconView: View {
     let frameIndex: Int
 
     var body: some View {
-        renderedImage
-            .renderingMode(.template)
+        Image(systemName: symbolName)
+            .font(.system(size: 15.5, weight: .regular))
+            .frame(width: 22, height: 22)
+            .rotationEffect(.degrees(isSyncing ? rotationDegrees : 0))
             .accessibilityLabel("NotesBridge")
     }
 
-    private var renderedImage: Image {
-        Image(
-            nsImage: MenuBarImageCache.shared.image(
-                symbolName: symbolName,
-                frameIndex: isSyncing ? frameIndex : 0,
-                isSyncing: isSyncing
-            )
-        )
-    }
-}
-
-@MainActor
-private final class MenuBarImageCache {
-    static let shared = MenuBarImageCache()
-
-    private let frameCount = 12
-    private let iconSize = NSSize(width: 22, height: 22)
-    private var cache: [String: NSImage] = [:]
-
-    func image(symbolName: String, frameIndex: Int, isSyncing: Bool) -> NSImage {
-        let normalizedFrame = isSyncing ? (((frameIndex % frameCount) + frameCount) % frameCount) : 0
-        let cacheKey = "\(symbolName)-\(normalizedFrame)-\(isSyncing)"
-
-        if let cachedImage = cache[cacheKey] {
-            return cachedImage
-        }
-
-        let image = makeImage(symbolName: symbolName, frameIndex: normalizedFrame, isSyncing: isSyncing)
-        cache[cacheKey] = image
-        return image
-    }
-
-    private func makeImage(symbolName: String, frameIndex: Int, isSyncing: Bool) -> NSImage {
-        // Point size 15.5 is often better for complex symbols to maintain padding
-        let configuration = NSImage.SymbolConfiguration(pointSize: 15.5, weight: .regular)
-        guard let baseImage = NSImage(
-            systemSymbolName: symbolName,
-            accessibilityDescription: "NotesBridge"
-        )?.withSymbolConfiguration(configuration) else {
-            return NSImage(size: iconSize)
-        }
-
-        let image = NSImage(size: iconSize)
-        image.lockFocus()
-
-        if isSyncing {
-            let center = NSPoint(x: iconSize.width / 2, y: iconSize.height / 2)
-            let rotation = NSAffineTransform()
-            rotation.translateX(by: center.x, yBy: center.y)
-            rotation.rotate(byDegrees: CGFloat(Double(frameIndex) * (360.0 / Double(frameCount))))
-            rotation.translateX(by: -center.x, yBy: -center.y)
-            rotation.concat()
-        }
-
-        // Visual adjustment: Shift down slightly (-1.0) to achieve visual vertical centering
-        let visualYOffset: CGFloat = -1.0
-        let drawRect = NSRect(
-            x: (iconSize.width - baseImage.size.width) / 2,
-            y: (iconSize.height - baseImage.size.height) / 2 + visualYOffset,
-            width: baseImage.size.width,
-            height: baseImage.size.height
-        )
-
-        baseImage.draw(
-            in: drawRect,
-            from: NSRect(origin: .zero, size: baseImage.size),
-            operation: .sourceOver,
-            fraction: 1
-        )
-        
-        image.unlockFocus()
-        image.isTemplate = true
-        return image
+    private var rotationDegrees: Double {
+        let frameCount = 12
+        let normalizedFrame = ((frameIndex % frameCount) + frameCount) % frameCount
+        return Double(normalizedFrame) * (360.0 / Double(frameCount))
     }
 }

--- a/Tests/NotesBridgeTests/ContextualSurfacePositioningTests.swift
+++ b/Tests/NotesBridgeTests/ContextualSurfacePositioningTests.swift
@@ -103,4 +103,24 @@ final class ContextualSurfacePositioningTests: XCTestCase {
         // 1000 - 260 - 8 = 732
         XCTAssertEqual(origin.x, 732)
     }
+
+    func testContextualSurfacePanelDoesNotUseRectangularWindowShadow() {
+        let panel = controller.makePanel(contentRect: CGRect(x: 0, y: 0, width: 200, height: 60))
+
+        XCTAssertFalse(panel.hasShadow)
+    }
+
+    func testSlashCommandPanelDoesNotUseRectangularWindowShadow() {
+        let slashController = SlashCommandMenuController(
+            onHoverIndex: { _ in },
+            onSelectIndex: { _ in },
+            onFrameUpdated: { _ in },
+            onKeyboardAction: { _ in },
+            onPassthroughKeyDown: { _ in }
+        )
+
+        let panel = slashController.makePanel(contentRect: CGRect(x: 0, y: 0, width: 260, height: 88))
+
+        XCTAssertFalse(panel.hasShadow)
+    }
 }

--- a/Tests/NotesBridgeTests/FormattingBarLayoutTests.swift
+++ b/Tests/NotesBridgeTests/FormattingBarLayoutTests.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import Testing
+@testable import NotesBridge
+
+struct FormattingBarLayoutTests {
+    @Test
+    func groupsPreserveCommandOrderAcrossStyleTransitions() {
+        let commands: [FormattingCommand] = [
+            .bold,
+            .title,
+            .insertLink,
+            .numberedList,
+            .quote,
+        ]
+
+        let groups = FormattingBarLayout.groups(for: commands)
+
+        #expect(groups.count == 5)
+        #expect(groups.flatMap { $0 } == commands)
+    }
+
+    @Test
+    func defaultVisibleCommandsCollapseIntoStableVisualClusters() {
+        let groups = FormattingBarLayout.groups(for: InlineToolbarItemSetting.defaultVisibleCommands)
+        let expected: [[FormattingCommand]] = [
+            [.title, .heading, .subheading, .body],
+            [.bold, .strikethrough, .insertLink],
+            [.checklist, .bulletedList, .dashedList, .numberedList],
+        ]
+
+        #expect(groups == expected)
+    }
+
+    @Test
+    func preferredSizeShrinksForCompactSetsAndCapsWideSets() {
+        let compact = FormattingBarLayout.preferredSize(for: [.bold, .insertLink])
+        let standard = FormattingBarLayout.preferredSize(for: InlineToolbarItemSetting.defaultVisibleCommands)
+        let expanded = FormattingBarLayout.preferredSize(for: FormattingCommand.allCases)
+
+        #expect(compact.width == FormattingBarLayout.minimumWidth)
+        #expect(compact.height == FormattingBarLayout.height)
+
+        #expect(standard.width == FormattingBarLayout.maximumWidth)
+        #expect(standard.height == FormattingBarLayout.height)
+
+        #expect(expanded.width == FormattingBarLayout.maximumWidth)
+        #expect(expanded.height == FormattingBarLayout.height)
+        #expect(compact.width < standard.width)
+    }
+
+    @Test
+    func preferredSizeIncludesOuterRenderingInsetAroundVisibleSurface() {
+        let commands: [FormattingCommand] = [.bold, .insertLink]
+        let surfaceSize = FormattingBarLayout.surfaceSize(for: commands)
+        let preferredSize = FormattingBarLayout.preferredSize(for: commands)
+
+        #expect(preferredSize.width == surfaceSize.width + (FormattingBarLayout.outerPadding * 2))
+        #expect(preferredSize.height == surfaceSize.height + (FormattingBarLayout.outerPadding * 2))
+    }
+}


### PR DESCRIPTION
## Summary
- Refresh the inline formatting toolbar with grouped commands, explicit hover/pressed states, adaptive width, and a dedicated layout model.
- Remove rectangular AppKit window shadows from floating contextual surfaces to avoid right-edge/bottom-edge glass artifacts.
- Render the menu bar icon directly with SwiftUI SF Symbols instead of cached template NSImages.

Closes #36

## Test Plan
- [x] `swift test`
- [x] `./scripts/notesbridge.sh bundle --debug --output-dir /tmp/notesbridge-pr-bundle`
- [x] `./scripts/notesbridge.sh dev` for bundled-app runtime check
