### PR TITLE
Update release workflow for Node 24 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
     tags:
       - "[0-9]*.[0-9]*.[0-9]*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-release:
     runs-on: macos-26
@@ -105,7 +108,7 @@ jobs:
           ./scripts/notesbridge.sh release
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: NotesBridge-${{ steps.meta.outputs.version }}-macOS
           path: |


### PR DESCRIPTION
## Summary

- Opt the release workflow into GitHub Actions Node.js 24 execution.
- Upgrade `actions/upload-artifact` from v4 to v7 so release artifact upload uses the Node 24 runtime.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml YAML OK"'`
- `git diff --check`
- Verified `actions/upload-artifact@v7` metadata declares `using: node24`.

## Notes

This addresses the Node.js 20 deprecation warning from the `0.2.10` release workflow without changing release triggers or artifact paths.
